### PR TITLE
feat(api): implement a basic /send endpoint

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,14 +1,7 @@
-control_brace_style = "AlwaysNextLine"
 brace_style = "AlwaysNextLine"
-where_single_line = true
 imports_indent = "Block"
-imports_layout = "HorizontalVertical"
 merge_imports = true
-match_block_trailing_comma = true
-normalize_comments = true
 reorder_impl_items = true
-spaces_around_ranges = true
-struct_lit_single_line = false
 tab_spaces = 2
 use_field_init_shorthand = true
 wrap_comments = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,4 +1,12 @@
 [[package]]
+name = "aho-corasick"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -17,13 +25,22 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "card-validate"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cfg-if"
@@ -73,11 +90,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -87,11 +109,17 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "fxa-email"
+name = "fxa-email-service"
 version = "0.1.0"
 dependencies = [
- "rocket 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket_codegen 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_codegen 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_contrib 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "validator 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "validator_derive 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -133,6 +161,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "if_chain"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "isatty"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -142,6 +175,11 @@ dependencies = [
  "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "kernel32-sys"
@@ -202,6 +240,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,6 +298,22 @@ version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "proc-macro2"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "quote"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rand"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +349,26 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "regex"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ring"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -300,7 +382,7 @@ dependencies = [
 
 [[package]]
 name = "rocket"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -314,7 +396,7 @@ dependencies = [
  "pear 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "pear_codegen 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "state 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "state 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -324,13 +406,24 @@ dependencies = [
 
 [[package]]
 name = "rocket_codegen"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "yansi 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rocket_contrib"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -349,14 +442,63 @@ version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "serde_derive"
+version = "1.0.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_internals 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "smallvec"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "state"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "syn"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "time"
@@ -387,6 +529,11 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "ucd-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "unicase"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -408,6 +555,19 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "unicode-xid"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unreachable"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "untrusted"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,8 +583,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "utf8-ranges"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "validator"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "card-validate 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "validator 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "version_check"
 version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "void"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -462,22 +658,27 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
+"checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
-"checksum bitflags 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b3c30d3802dfb7281680d6285f2ccdaa8c2d8fee41f93805dba5c4cf50dc23cf"
+"checksum bitflags 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1b2bf7093258c32e0825b635948de528a5949799dcd61bef39534c8aab95870c"
 "checksum byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b5bdfe7ee3ad0b99c9801d58807a9dbc9e09196365b0203853b99889ab3c87"
+"checksum card-validate 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "377e2cbab679f09143661a24262602f6f5e0fb20d164b464c0fc25c4268937c9"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum cookie 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "477eb650753e319be2ae77ec368a58c638f9f0c4d941c39bad95e950fb1d1d0d"
 "checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
 "checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
 "checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
+"checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2f407128745b78abc95c0ffbe4e5d37427fdc0d45470710cfef8c44522a2e37"
 "checksum hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)" = "368cb56b2740ebf4230520e2b90ebb0461e69034d85d1945febd9b3971426db2"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
+"checksum if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "61bb90bdd39e3af69b0172dfc6130f6cd6332bf040fbb9bdd4401d37adbd48b8"
 "checksum isatty 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a118a53ba42790ef25c82bb481ecf36e2da892646cccd361e69a6bb881e19398"
+"checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
@@ -487,6 +688,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
+"checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
@@ -495,28 +697,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum pear 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "b9b645aa07cf1010a67e9f67b4b9b96d6c5fb9315eee678a061d6ab58e9cb77f"
 "checksum pear_codegen 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ca34109829349aeefe22772916da5404b3f5cd0e63a72c5d91209fc809342265"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
+"checksum proc-macro2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b16749538926f394755373f0dfec0852d79b3bd512a5906ceaeb72ee64a4eaa0"
+"checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum rayon 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a77c51c07654ddd93f6cb543c7a849863b03abc7e82591afda6dc8ad4ac3ac4a"
 "checksum rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d24ad214285a7729b174ed6d3bcfcb80177807f959d95fafd5bfc5c4f201ac8"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
+"checksum regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "aec3f58d903a7d2a9dc2bf0e41a746f4530e0cab6b615494e058f67a3ef947fb"
+"checksum regex-syntax 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bd90079345f4a4c3409214734ae220fd773c6f2e8a543d07370c6c1c369cfbfb"
 "checksum ring 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2a6dc7fc06a05e6de183c5b97058582e9da2de0c136eafe49609769c507724"
-"checksum rocket 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c000cf7233aa997a19a43f77ddc80db11b58cdbbc12e2c1385bd62cbbace3964"
-"checksum rocket_codegen 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "645dd494d1340a4c16ba8decc4bb94d3e687a7e6b57552e2341dbf436b75ffaa"
+"checksum rocket 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f5582b29c859a8df0c685d3755501f8eb4ee04805cf879e0bfbce03e6805f370"
+"checksum rocket_codegen 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "07707250bb270c758f5d68398b4d9ae518798fff60d8376bd136115b810af592"
+"checksum rocket_contrib 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8d3fed1d762e7748aac90894503ca11dad67a7a22811fcca6b9ab9ec28bc451"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)" = "0c855d888276f20d140223bd06515e5bf1647fd6d02593cb5792466d9a8ec2d0"
+"checksum serde_derive 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)" = "aa113e5fc4b008a626ba2bbd41330b56c9987d667f79f7b243e5a2d03d91ed1c"
+"checksum serde_derive_internals 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9d30c4596450fd7bbda79ef15559683f9a79ac0193ea819db90000d7e1cae794"
+"checksum serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "8c6c4e049dc657a99e394bd85c22acbf97356feeec6dbf44150f2dcf79fb3118"
 "checksum smallvec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ee4f357e8cd37bf8822e1b964e96fd39e2cb5a0424f8aaa284ccaccc2162411c"
-"checksum state 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d5562ac59585fe3d9a1ccf6b4e298ce773f5063db80d59f783776b410c1714c2"
+"checksum state 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7345c971d1ef21ffdbd103a75990a15eb03604fc8b8852ca8cb418ee1a099028"
+"checksum syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "91b52877572087400e83d24b9178488541e3d535259e04ff17a63df1e5ceff59"
+"checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "a15375f1df02096fb3317256ce2cee6a1f42fc84ea5ad5fc8c421cfe40c73098"
 "checksum toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a0263c6c02c4db6c8f7681f9fd35e90de799ebd4cfdeab77a38f4ff6b3d8c0d9"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
+"checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "51ccda9ef9efa3f7ef5d91e8f9b83bbe6955f9bf86aec89d5cce2c874625920f"
+"checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
+"checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f392d7819dbe58833e26872f5f6f0d68b7bbbe90fc3667e98731c4a15ad9a7ae"
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
+"checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
+"checksum validator 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0ee73a134910391b2a3ffd99f5ba0a67ebc0731e7cf92d56b6dccd1542823163"
+"checksum validator_derive 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ac6c1c4023f5feb24a1b54a02e8828ae231659cf72b20f6191a0656163a4ca12"
 "checksum version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6b772017e347561807c1aa192438c5fd74242a670a6cffacc40f2defd1dc069d"
+"checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "04e3bd221fcbe8a271359c04f21a76db7d0c6028862d1bb5512d85e1e2eb5bb3"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,5 +3,11 @@ name = "fxa-email-service"
 version = "0.1.0"
 
 [dependencies]
-rocket = "0.3.8"
-rocket_codegen = "0.3.8"
+rocket = "0.3.9"
+rocket_codegen = "0.3.9"
+rocket_contrib = "0.3.9"
+serde = "1.0"
+serde_derive = "1.0"
+serde_json = "1.0"
+validator = "0.6.3"
+validator_derive = "0.6.5"

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,14 +2,16 @@
 #![plugin(rocket_codegen)]
 
 extern crate rocket;
+#[macro_use]
+extern crate rocket_contrib;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
+extern crate validator;
 
-#[get("/")]
-fn index() -> &'static str
-{
-  "Hello, world!"
-}
+mod send;
 
 fn main()
 {
-  rocket::ignite().mount("/", routes![index]).launch();
+  rocket::ignite().mount("/", routes![send::handler]).launch();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,8 @@ extern crate rocket_contrib;
 extern crate serde_derive;
 extern crate serde_json;
 extern crate validator;
+#[macro_use]
+extern crate validator_derive;
 
 mod send;
 

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -1,0 +1,100 @@
+use std::{borrow::Cow, collections::HashMap};
+
+use rocket::{
+  data::{self, FromData},
+  http::Status,
+  Data,
+  Outcome,
+  Request,
+};
+use rocket_contrib::{Json, Value};
+use validator::{self, ValidationError};
+
+#[cfg(test)]
+mod test;
+
+#[derive(Debug, Deserialize)]
+struct Body
+{
+  text: String,
+  html: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct Email
+{
+  to: Vec<String>,
+  cc: Option<Vec<String>>,
+  subject: String,
+  body: Body,
+}
+
+impl FromData for Email
+{
+  type Error = ValidationError;
+
+  fn from_data(request: &Request, data: Data) -> data::Outcome<Self, Self::Error>
+  {
+    let result = Json::<Email>::from_data(request, data);
+    match result
+    {
+      Outcome::Success(json) =>
+      {
+        let email = json.into_inner();
+
+        if email.to.len() == 0
+        {
+          return fail();
+        }
+
+        if let Some(outcome) = validate_addresses(&email.to)
+        {
+          return outcome;
+        }
+
+        if let Some(ref cc) = email.cc
+        {
+          if let Some(outcome) = validate_addresses(&cc)
+          {
+            return outcome;
+          }
+        }
+
+        Outcome::Success(email)
+      },
+      Outcome::Failure(_error) => fail(),
+      Outcome::Forward(forward) => Outcome::Forward(forward),
+    }
+  }
+}
+
+fn fail() -> data::Outcome<Email, ValidationError>
+{
+  Outcome::Failure((
+    Status::BadRequest,
+    ValidationError {
+      code: Cow::from("400"),
+      message: None,
+      params: HashMap::new(),
+    },
+  ))
+}
+
+fn validate_addresses(addresses: &[String]) -> Option<data::Outcome<Email, ValidationError>>
+{
+  for address in addresses
+  {
+    if !validator::validate_email(&address)
+    {
+      return Some(fail());
+    }
+  }
+
+  None
+}
+
+#[post("/send", format = "application/json", data = "<_email>")]
+fn handler(_email: Email) -> Json<Value>
+{
+  Json(json!({ "messageId": 0 }))
+}

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -37,20 +37,15 @@ impl FromData for Email
   fn from_data(request: &Request, data: Data) -> data::Outcome<Self, Self::Error>
   {
     let result = Json::<Email>::from_data(request, data);
-    match result
-    {
-      Outcome::Success(json) =>
-      {
+    match result {
+      Outcome::Success(json) => {
         let email = json.into_inner();
-        if validate(&email)
-        {
+        if validate(&email) {
           Outcome::Success(email)
-        }
-        else
-        {
+        } else {
           fail()
         }
-      },
+      }
       Outcome::Failure(_error) => fail(),
       Outcome::Forward(forward) => Outcome::Forward(forward),
     }
@@ -59,12 +54,9 @@ impl FromData for Email
 
 fn validate(email: &Email) -> bool
 {
-  if let Some(ref cc) = email.cc
-  {
-    for address in cc
-    {
-      if !validator::validate_email(&address)
-      {
+  if let Some(ref cc) = email.cc {
+    for address in cc {
+      if !validator::validate_email(&address) {
         return false;
       }
     }

--- a/src/send/test.rs
+++ b/src/send/test.rs
@@ -21,7 +21,7 @@ fn single_recipient()
     .header(ContentType::JSON)
     .body(
       r#"{
-      "to": [ "foo@example.com" ],
+      "to": "foo@example.com",
       "cc": [],
       "subject": "bar",
       "body": {
@@ -48,8 +48,8 @@ fn multiple_recipients()
     .header(ContentType::JSON)
     .body(
       r#"{
-      "to": [ "foo@example.com", "bar@example.com" ],
-      "cc": [ "baz@example.com", "qux@example.com" ],
+      "to": "foo@example.com",
+      "cc": [ "bar@example.com", "baz@example.com" ],
       "subject": "wibble",
       "body": {
         "text": "blee",
@@ -75,7 +75,7 @@ fn without_optional_data()
     .header(ContentType::JSON)
     .body(
       r#"{
-      "to": [ "foo@example.com" ],
+      "to": "foo@example.com",
       "subject": "bar",
       "body": {
         "text": "baz"
@@ -146,28 +146,6 @@ fn missing_body_text_field()
       "subject": "bar",
       "body": {
         "html": "<a>qux</a>"
-      }
-    }"#,
-    )
-    .dispatch();
-
-  assert_eq!(response.status(), Status::BadRequest);
-}
-
-#[test]
-fn empty_to_field()
-{
-  let client = setup();
-
-  let response = client
-    .post("/send")
-    .header(ContentType::JSON)
-    .body(
-      r#"{
-      "to": [],
-      "subject": "bar",
-      "body": {
-        "text": "baz"
       }
     }"#,
     )

--- a/src/send/test.rs
+++ b/src/send/test.rs
@@ -1,0 +1,222 @@
+use rocket::{
+  self,
+  http::{ContentType, Status},
+  local::Client,
+};
+
+fn setup() -> Client
+{
+  let server = rocket::ignite().mount("/", routes![super::handler]);
+
+  Client::new(server).unwrap()
+}
+
+#[test]
+fn single_recipient()
+{
+  let client = setup();
+
+  let mut response = client
+    .post("/send")
+    .header(ContentType::JSON)
+    .body(
+      r#"{
+      "to": [ "foo@example.com" ],
+      "cc": [],
+      "subject": "bar",
+      "body": {
+        "text": "baz",
+        "html": "<a>qux</a>"
+      }
+    }"#,
+    )
+    .dispatch();
+
+  assert_eq!(response.status(), Status::Ok);
+
+  let body = response.body().unwrap().into_string().unwrap();
+  assert_eq!(body, json!({ "messageId": 0 }).to_string());
+}
+
+#[test]
+fn multiple_recipients()
+{
+  let client = setup();
+
+  let mut response = client
+    .post("/send")
+    .header(ContentType::JSON)
+    .body(
+      r#"{
+      "to": [ "foo@example.com", "bar@example.com" ],
+      "cc": [ "baz@example.com", "qux@example.com" ],
+      "subject": "wibble",
+      "body": {
+        "text": "blee",
+        "html": ""
+      }
+    }"#,
+    )
+    .dispatch();
+
+  assert_eq!(response.status(), Status::Ok);
+
+  let body = response.body().unwrap().into_string().unwrap();
+  assert_eq!(body, json!({ "messageId": 0 }).to_string());
+}
+
+#[test]
+fn without_optional_data()
+{
+  let client = setup();
+
+  let mut response = client
+    .post("/send")
+    .header(ContentType::JSON)
+    .body(
+      r#"{
+      "to": [ "foo@example.com" ],
+      "subject": "bar",
+      "body": {
+        "text": "baz"
+      }
+    }"#,
+    )
+    .dispatch();
+
+  assert_eq!(response.status(), Status::Ok);
+
+  let body = response.body().unwrap().into_string().unwrap();
+  assert_eq!(body, json!({ "messageId": 0 }).to_string());
+}
+
+#[test]
+fn missing_to_field()
+{
+  let client = setup();
+
+  let response = client
+    .post("/send")
+    .header(ContentType::JSON)
+    .body(
+      r#"{
+      "subject": "bar",
+      "body": {
+        "text": "baz"
+      }
+    }"#,
+    )
+    .dispatch();
+
+  assert_eq!(response.status(), Status::BadRequest);
+}
+
+#[test]
+fn missing_subject_field()
+{
+  let client = setup();
+
+  let response = client
+    .post("/send")
+    .header(ContentType::JSON)
+    .body(
+      r#"{
+      "to": [ "foo@example.com" ],
+      "body": {
+        "text": "baz"
+      }
+    }"#,
+    )
+    .dispatch();
+
+  assert_eq!(response.status(), Status::BadRequest);
+}
+
+#[test]
+fn missing_body_text_field()
+{
+  let client = setup();
+
+  let response = client
+    .post("/send")
+    .header(ContentType::JSON)
+    .body(
+      r#"{
+      "to": [ "foo@example.com" ],
+      "subject": "bar",
+      "body": {
+        "html": "<a>qux</a>"
+      }
+    }"#,
+    )
+    .dispatch();
+
+  assert_eq!(response.status(), Status::BadRequest);
+}
+
+#[test]
+fn empty_to_field()
+{
+  let client = setup();
+
+  let response = client
+    .post("/send")
+    .header(ContentType::JSON)
+    .body(
+      r#"{
+      "to": [],
+      "subject": "bar",
+      "body": {
+        "text": "baz"
+      }
+    }"#,
+    )
+    .dispatch();
+
+  assert_eq!(response.status(), Status::BadRequest);
+}
+
+#[test]
+fn invalid_to_field()
+{
+  let client = setup();
+
+  let response = client
+    .post("/send")
+    .header(ContentType::JSON)
+    .body(
+      r#"{
+      "to": [ "foo" ],
+      "subject": "bar",
+      "body": {
+        "text": "baz"
+      }
+    }"#,
+    )
+    .dispatch();
+
+  assert_eq!(response.status(), Status::BadRequest);
+}
+
+#[test]
+fn invalid_cc_field()
+{
+  let client = setup();
+
+  let response = client
+    .post("/send")
+    .header(ContentType::JSON)
+    .body(
+      r#"{
+      "to": [ "foo@example.com" ],
+      "cc": [ "bar" ],
+      "subject": "baz",
+      "body": {
+        "text": "qux"
+      }
+    }"#,
+    )
+    .dispatch();
+
+  assert_eq!(response.status(), Status::BadRequest);
+}


### PR DESCRIPTION
Fixes #1.

Not wired in to any behaviour, just does some crude validation and then returns a hard-coded message id. There is some test coverage, but also some gaps where I haven't figured out how we should do stuff yet:

* The validation code is punishingly verbose. I evauated a couple of crates to implement validation, `accord` and `validator`, and opted for `validator`. However they both seem quite simple, for instance there's no support for nested objects or values packed inside arrays. This meant we couldn't lean on the nice, readable macro syntax that's available and have to explitly validate fields using Rocket's `FromData` trait instead.

* Rocket has a feature called error catchers, which I couldn't get to work. These are supposed to let you return custom error data but, no matter what I tried, it always seemed to return the default error response for each type (which is an html string). And even if I could get those to work, I couldn't see a way to propagate rich error information, e.g. names of invalid parameters, into the catcher without having to validate all of the parameters a second time inside the catcher.

* I tried to write a test case that fired unicode at the endpoint and it failed.

I'm sure the root cause of these problems is just my own lack of expertise and we'll figure it out eventually. In the meantime, this seemed like enough to get us started. I'll open issues to cover all of the above.

In terms of code structure, I've just lumped most stuff in to the `send` module for now. As we add more functionality, I expect the natural boundaries to reveal themselves. No point agonising over it yet.

@rfk, @mozilla/fxa-devs r?