### PR TITLE
feat(config): add configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 **/*.rs.bk
+config/local.*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,5 +1,13 @@
 [[package]]
 name = "aho-corasick"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "aho-corasick"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -46,6 +54,20 @@ dependencies = [
 name = "cfg-if"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "config"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde-hjson 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "cookie"
@@ -112,6 +134,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "fxa-email-service"
 version = "0.1.0"
 dependencies = [
+ "config 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_codegen 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_contrib 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -211,6 +236,20 @@ version = "0.2.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_test 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "log"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,6 +269,14 @@ dependencies = [
 name = "matches"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "memchr"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "memchr"
@@ -263,6 +310,27 @@ dependencies = [
 [[package]]
 name = "nodrop"
 version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "nom"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -350,6 +418,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex"
+version = "0.1.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -359,6 +439,11 @@ dependencies = [
  "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex-syntax"
@@ -438,8 +523,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
 version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde-hjson"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "serde_derive"
@@ -472,6 +574,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_test"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "smallvec"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -489,6 +599,23 @@ dependencies = [
  "proc-macro2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread-id"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -584,6 +711,11 @@ dependencies = [
 
 [[package]]
 name = "utf8-ranges"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "utf8-ranges"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -653,11 +785,20 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "yaml-rust"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "yansi"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
+"checksum aho-corasick 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ca972c2ea5f742bfce5687b9aef75506a764f61d37f8f649047846a9686ddb66"
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
@@ -665,6 +806,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b5bdfe7ee3ad0b99c9801d58807a9dbc9e09196365b0203853b99889ab3c87"
 "checksum card-validate 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "377e2cbab679f09143661a24262602f6f5e0fb20d164b464c0fc25c4268937c9"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
+"checksum config 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e595d1735d8ab6b04906bbdcfc671cce2a5e609b6f8e92865e67331cc2f41ba4"
 "checksum cookie 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "477eb650753e319be2ae77ec368a58c638f9f0c4d941c39bad95e950fb1d1d0d"
 "checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
 "checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
@@ -684,14 +826,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
+"checksum linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd"
+"checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
+"checksum memchr 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d8b629fb514376c675b98c1421e80b151d3817ac42d7c667717d282761418d20"
 "checksum memchr 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "148fab2e51b4f1cfc66da2a7c32981d1d3c083a803978268bb11fe4b86925e7a"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0f9dc261e2b62d7a622bf416ea3c5245cdd5d9a7fcc428c0d06804dfce1775b3"
 "checksum mime 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "ba626b8a6de5da682e1caa06bdb42a335aee5a84db8e5046a3e8ab17ba0a3ae0"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
+"checksum nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05aec50c70fd288702bcd93284a8444607f3292dbdf2a30de5ea5dcdbe72287b"
+"checksum num-traits 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)" = "92e5113e9fd4cc14ded8e499429f396a20f98c772a47cc8622a736e1ec843c31"
+"checksum num-traits 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dee092fcdf725aee04dd7da1d21debff559237d49ef1cb3e69bcb8ece44c7364"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b81cf3b8cb96aa0e73bbedfcdc9708d09fec2854ba8d474be4e6f666d7379e8b"
 "checksum pear 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "b9b645aa07cf1010a67e9f67b4b9b96d6c5fb9315eee678a061d6ab58e9cb77f"
@@ -703,7 +851,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rayon 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a77c51c07654ddd93f6cb543c7a849863b03abc7e82591afda6dc8ad4ac3ac4a"
 "checksum rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d24ad214285a7729b174ed6d3bcfcb80177807f959d95fafd5bfc5c4f201ac8"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
+"checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
 "checksum regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "aec3f58d903a7d2a9dc2bf0e41a746f4530e0cab6b615494e058f67a3ef947fb"
+"checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
 "checksum regex-syntax 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bd90079345f4a4c3409214734ae220fd773c6f2e8a543d07370c6c1c369cfbfb"
 "checksum ring 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2a6dc7fc06a05e6de183c5b97058582e9da2de0c136eafe49609769c507724"
 "checksum rocket 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f5582b29c859a8df0c685d3755501f8eb4ee04805cf879e0bfbce03e6805f370"
@@ -711,13 +861,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rocket_contrib 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e8d3fed1d762e7748aac90894503ca11dad67a7a22811fcca6b9ab9ec28bc451"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
+"checksum serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
 "checksum serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)" = "0c855d888276f20d140223bd06515e5bf1647fd6d02593cb5792466d9a8ec2d0"
+"checksum serde-hjson 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a2376ebb8976138927f48b49588ef73cde2f6591b8b3df22f4063e0f27b9bec"
 "checksum serde_derive 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)" = "aa113e5fc4b008a626ba2bbd41330b56c9987d667f79f7b243e5a2d03d91ed1c"
 "checksum serde_derive_internals 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9d30c4596450fd7bbda79ef15559683f9a79ac0193ea819db90000d7e1cae794"
 "checksum serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "8c6c4e049dc657a99e394bd85c22acbf97356feeec6dbf44150f2dcf79fb3118"
+"checksum serde_test 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "110b3dbdf8607ec493c22d5d947753282f3bae73c0f56d322af1e8c78e4c23d5"
 "checksum smallvec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ee4f357e8cd37bf8822e1b964e96fd39e2cb5a0424f8aaa284ccaccc2162411c"
 "checksum state 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7345c971d1ef21ffdbd103a75990a15eb03604fc8b8852ca8cb418ee1a099028"
 "checksum syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "91b52877572087400e83d24b9178488541e3d535259e04ff17a63df1e5ceff59"
+"checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
+"checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
 "checksum time 0.1.39 (registry+https://github.com/rust-lang/crates.io-index)" = "a15375f1df02096fb3317256ce2cee6a1f42fc84ea5ad5fc8c421cfe40c73098"
 "checksum toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a0263c6c02c4db6c8f7681f9fd35e90de799ebd4cfdeab77a38f4ff6b3d8c0d9"
@@ -731,6 +886,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f392d7819dbe58833e26872f5f6f0d68b7bbbe90fc3667e98731c4a15ad9a7ae"
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
+"checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"
 "checksum validator 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0ee73a134910391b2a3ffd99f5ba0a67ebc0731e7cf92d56b6dccd1542823163"
 "checksum validator_derive 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ac6c1c4023f5feb24a1b54a02e8828ae231659cf72b20f6191a0656163a4ca12"
@@ -741,4 +897,5 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57ab38ee1a4a266ed033496cf9af1828d8d6e6c1cfa5f643a2809effcae4d628"
 "checksum yansi 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d60c3b48c9cdec42fb06b3b84b5b087405e1fa1c644a1af3930e4dfafe93de48"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,9 @@ name = "fxa-email-service"
 version = "0.1.0"
 
 [dependencies]
+config = "0.8.0"
+lazy_static = "1.0"
+regex = "0.2.10"
 rocket = "0.3.9"
 rocket_codegen = "0.3.9"
 rocket_contrib = "0.3.9"

--- a/config/default.json
+++ b/config/default.json
@@ -1,0 +1,7 @@
+{
+  "smtp": {
+    "host": "127.0.0.1",
+    "port": 25,
+    "sender": "Firefox Accounts <accounts@firefox.com>"
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,14 @@
 #![feature(plugin)]
 #![plugin(rocket_codegen)]
 
+extern crate config;
+#[macro_use]
+extern crate lazy_static;
+extern crate regex;
 extern crate rocket;
 #[macro_use]
 extern crate rocket_contrib;
+extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
@@ -12,6 +17,7 @@ extern crate validator;
 extern crate validator_derive;
 
 mod send;
+mod settings;
 
 fn main()
 {

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -10,8 +10,14 @@ use rocket::{
 use rocket_contrib::{Json, Value};
 use validator::{self, Validate, ValidationError};
 
+use settings::Settings;
+
 #[cfg(test)]
 mod test;
+
+lazy_static! {
+  static ref SETTINGS: Settings = Settings::new().expect("Config error");
+}
 
 #[derive(Debug, Deserialize)]
 struct Body

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -1,0 +1,88 @@
+use std::env;
+
+use config::{Config, ConfigError, Environment, File};
+use regex::Regex;
+use serde::de::{Error, Unexpected};
+
+#[cfg(test)]
+mod test;
+
+lazy_static! {
+  static ref HOST_FORMAT: Regex = Regex::new("^[A-Za-z0-9-]+(?:\\.[A-Za-z0-9-]+)*$").unwrap();
+  static ref SENDER_FORMAT: Regex = Regex::new(
+    "^[A-Za-z0-9-]+(?: [A-Za-z0-9-]+)* <[a-z0-9-]+@[a-z0-9-]+(?:\\.[a-z0-9-]+)+>$"
+  ).unwrap();
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Smtp
+{
+  host: String,
+  port: u16,
+  user: Option<String>,
+  password: Option<String>,
+  sender: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Settings
+{
+  smtp: Smtp,
+}
+
+impl Settings
+{
+  /// Construct a `Settings` instance, populating it with data from the file
+  /// system and local environment.
+  ///
+  /// Precedence (earlier items override later ones):
+  ///
+  ///   1. Environment variables: `$FXA_<UPPERCASE_KEY_NAME>`
+  ///   2. File: `config/local.json`
+  ///   3. File: `config/<$NODE_ENV>.json`
+  ///   4. File: `config/default.json`
+  ///
+  /// `$NODE_ENV` is used so that this service automatically picks up the
+  /// appropriate state from our existing node.js ecosystem, without needing
+  /// to manage an extra environment variable.
+  ///
+  /// Immediately before returning, the parsed config object will be logged to
+  /// the console.
+  pub fn new() -> Result<Self, ConfigError>
+  {
+    let mut config = Config::new();
+
+    config.merge(File::with_name("config/default"))?;
+
+    if let Ok(node_env) = env::var("NODE_ENV") {
+      config.merge(File::with_name(&format!("config/{}", node_env)).required(false))?;
+    }
+
+    config.merge(File::with_name("config/local").required(false))?;
+
+    config.merge(Environment::with_prefix("fxa"))?;
+
+    match config.try_into::<Settings>() {
+      Ok(settings) => {
+        if !HOST_FORMAT.is_match(&settings.smtp.host) {
+          return Err(ConfigError::invalid_value(
+            Unexpected::Str(&settings.smtp.host),
+            &"host name or IP address",
+          ));
+        }
+
+        if !SENDER_FORMAT.is_match(&settings.smtp.sender) {
+          return Err(ConfigError::invalid_value(
+            Unexpected::Str(&settings.smtp.sender),
+            &"name and email address",
+          ));
+        }
+
+        // TODO: replace this with proper logging when we have it
+        println!("config: {:?}", settings);
+        Ok(settings)
+      }
+      Err(error) => Err(error),
+    }
+  }
+}

--- a/src/settings/test.rs
+++ b/src/settings/test.rs
@@ -1,0 +1,144 @@
+use std::{
+  collections::{HashMap, HashSet},
+  env,
+  error::Error,
+  sync::{LockResult, Mutex, MutexGuard},
+};
+
+use super::*;
+
+lazy_static! {
+  // HACK: mutex to prevent tests clobbering each other's environment variables
+  static ref ENVIRONMENT_MUTEX: Mutex<bool> = Mutex::new(true);
+}
+
+struct CleanEnvironment<'e>
+{
+  vars_to_reinstate: HashMap<String, String>,
+  keys_to_clear: HashSet<String>,
+  _lock: LockResult<MutexGuard<'e, bool>>,
+}
+
+impl<'e> CleanEnvironment<'e>
+{
+  pub fn new(keys: Vec<&str>) -> CleanEnvironment
+  {
+    let mut snapshot = CleanEnvironment {
+      vars_to_reinstate: HashMap::new(),
+      keys_to_clear: HashSet::new(),
+      _lock: ENVIRONMENT_MUTEX.lock(),
+    };
+
+    snapshot.initialise(keys);
+
+    snapshot
+  }
+
+  fn initialise(&mut self, keys: Vec<&str>)
+  {
+    for key in keys {
+      if let Ok(value) = env::var(key) {
+        self.vars_to_reinstate.insert(String::from(key), value);
+        env::remove_var(key);
+      } else {
+        self.keys_to_clear.insert(String::from(key));
+      }
+    }
+  }
+}
+
+impl<'e> Drop for CleanEnvironment<'e>
+{
+  fn drop(&mut self)
+  {
+    for (key, value) in &self.vars_to_reinstate {
+      env::set_var(key, &value);
+    }
+
+    for key in &self.keys_to_clear {
+      env::remove_var(key);
+    }
+  }
+}
+
+#[test]
+fn env_vars_take_precedence()
+{
+  let _clean_env = CleanEnvironment::new(vec![
+    "FXA_SMTP_HOST",
+    "FXA_SMTP_PORT",
+    "FXA_SMTP_SENDER",
+    "FXA_SMTP_USER",
+    "FXA_SMTP_PASSWORD",
+  ]);
+
+  match Settings::new() {
+    Ok(settings) => {
+      let host = format!("{}{}", settings.smtp.host, "1");
+      let port = settings.smtp.port + 2;
+      let sender = format!("{}{}", "3", settings.smtp.sender);
+      let user = if let Some(ref user) = settings.smtp.user {
+        format!("{}{}", user, "4")
+      } else {
+        String::from("4")
+      };
+      let password = if let Some(ref password) = settings.smtp.password {
+        format!("{}{}", password, "5")
+      } else {
+        String::from("5")
+      };
+
+      env::set_var("FXA_SMTP_HOST", &host);
+      env::set_var("FXA_SMTP_PORT", &port.to_string());
+      env::set_var("FXA_SMTP_SENDER", &sender);
+      env::set_var("FXA_SMTP_USER", &user);
+      env::set_var("FXA_SMTP_PASSWORD", &password);
+
+      match Settings::new() {
+        Ok(env_settings) => {
+          assert_eq!(env_settings.smtp.host, host);
+          assert_eq!(env_settings.smtp.port, port);
+          assert_eq!(env_settings.smtp.sender, sender);
+
+          if let Some(env_user) = env_settings.smtp.user {
+            assert_eq!(env_user, user);
+          } else {
+            assert!(false, "smtp.user was not set");
+          }
+
+          if let Some(env_password) = env_settings.smtp.password {
+            assert_eq!(env_password, password);
+          } else {
+            assert!(false, "smtp.password was not set");
+          }
+        }
+        Err(error) => assert!(false, error),
+      }
+    }
+    Err(error) => assert!(false, error),
+  }
+}
+
+#[test]
+fn invalid_host()
+{
+  let _clean_env = CleanEnvironment::new(vec!["FXA_SMTP_HOST"]);
+  env::set_var("FXA_SMTP_HOST", "https://mail.google.com/");
+
+  match Settings::new() {
+    Ok(_settings) => assert!(false, "Settings::new should have failed"),
+    Err(error) => assert_eq!(error.description(), "configuration error"),
+  }
+}
+
+#[test]
+fn invalid_sender()
+{
+  let _clean_env = CleanEnvironment::new(vec!["FXA_SMTP_SENDER"]);
+  env::set_var("FXA_SMTP_SENDER", "wibble");
+
+  match Settings::new() {
+    Ok(_settings) => assert!(false, "Settings::new should have failed"),
+    Err(error) => assert_eq!(error.description(), "configuration error"),
+  }
+}


### PR DESCRIPTION
Imitates, as closely as possible, the convict-based approach we use in our node repos. The major difference is that validation here has to happen in the code, we can't define it in config.

Settings are applied in the following order:

* `config/default.json`
* `config/${NODE_ENV}.json` (optional)
* `config/local.json` (optional, git-ignored)
* environment variables

I opted to re-use `$NODE_ENV` instead of some rust-specific environment variable so that our dev setups will work with minimal changes. One less environment variable to manage feels like a win to me but if it seems too weird I can change it.

Uses the `config` crate, which was the convictiest dependency I could find.

Initially I was going to include this in the changeset for #2, but it seems worthy of code review in its own right and may be of use independently if people want to pick up other issues before that PR is ready.

@rfk, @mozilla/fxa-devs r?