### PR TITLE
refactor(settings): extract types for deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -47,7 +47,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -58,13 +58,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "config"
 version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/ivanovaleksey/config-rs?branch=issue-70#375befa7ddbdb1761611947226a0c117f4c35a5e"
 dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-hjson 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -121,7 +121,7 @@ name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "bitflags 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -134,15 +134,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "fxa-email-service"
 version = "0.1.0"
 dependencies = [
- "config 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "config 0.8.0 (git+https://github.com/ivanovaleksey/config-rs?branch=issue-70)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_codegen 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_contrib 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "validator 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "validator_derive 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -182,7 +182,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-normalization 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -367,7 +367,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -378,7 +378,7 @@ name = "quote"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -430,12 +430,12 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex-syntax 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -447,7 +447,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "regex-syntax"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -507,8 +507,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -528,7 +528,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.43"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -545,13 +545,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.43"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive_internals 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -559,18 +559,18 @@ name = "serde_derive_internals"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.16"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -593,10 +593,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.13.1"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -642,7 +642,7 @@ name = "toml"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -678,7 +678,7 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -727,10 +727,10 @@ dependencies = [
  "card-validate 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -741,7 +741,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "validator 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -802,11 +802,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum aho-corasick 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "d6531d44de723825aa81398a6415283229725a00fa30713812ab9323faa82fc4"
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 "checksum base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96434f987501f0ed4eb336a411e0631ecd1afa11574fe148587adc4ff96143c9"
-"checksum bitflags 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1b2bf7093258c32e0825b635948de528a5949799dcd61bef39534c8aab95870c"
+"checksum bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c54bb8f454c567f21197eefcdbf5679d0bd99f2ddbe52e84c77061952e6789"
 "checksum byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "73b5bdfe7ee3ad0b99c9801d58807a9dbc9e09196365b0203853b99889ab3c87"
 "checksum card-validate 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "377e2cbab679f09143661a24262602f6f5e0fb20d164b464c0fc25c4268937c9"
 "checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
-"checksum config 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e595d1735d8ab6b04906bbdcfc671cce2a5e609b6f8e92865e67331cc2f41ba4"
+"checksum config 0.8.0 (git+https://github.com/ivanovaleksey/config-rs?branch=issue-70)" = "<none>"
 "checksum cookie 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "477eb650753e319be2ae77ec368a58c638f9f0c4d941c39bad95e950fb1d1d0d"
 "checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
 "checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
@@ -845,16 +845,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum pear 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "b9b645aa07cf1010a67e9f67b4b9b96d6c5fb9315eee678a061d6ab58e9cb77f"
 "checksum pear_codegen 0.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "ca34109829349aeefe22772916da5404b3f5cd0e63a72c5d91209fc809342265"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
-"checksum proc-macro2 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b16749538926f394755373f0dfec0852d79b3bd512a5906ceaeb72ee64a4eaa0"
+"checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
 "checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum rayon 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a77c51c07654ddd93f6cb543c7a849863b03abc7e82591afda6dc8ad4ac3ac4a"
 "checksum rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d24ad214285a7729b174ed6d3bcfcb80177807f959d95fafd5bfc5c4f201ac8"
 "checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
-"checksum regex 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)" = "aec3f58d903a7d2a9dc2bf0e41a746f4530e0cab6b615494e058f67a3ef947fb"
+"checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
-"checksum regex-syntax 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "bd90079345f4a4c3409214734ae220fd773c6f2e8a543d07370c6c1c369cfbfb"
+"checksum regex-syntax 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
 "checksum ring 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2a6dc7fc06a05e6de183c5b97058582e9da2de0c136eafe49609769c507724"
 "checksum rocket 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f5582b29c859a8df0c685d3755501f8eb4ee04805cf879e0bfbce03e6805f370"
 "checksum rocket_codegen 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "07707250bb270c758f5d68398b4d9ae518798fff60d8376bd136115b810af592"
@@ -862,15 +862,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum safemem 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e27a8b19b835f7aea908818e871f5cc3a5a186550c30773be987e155e8163d8f"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
-"checksum serde 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)" = "0c855d888276f20d140223bd06515e5bf1647fd6d02593cb5792466d9a8ec2d0"
+"checksum serde 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "6a49d806123bcdaacdefe7aab3721c64ec11d05921bf64d888a857d3a92024a0"
 "checksum serde-hjson 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a2376ebb8976138927f48b49588ef73cde2f6591b8b3df22f4063e0f27b9bec"
-"checksum serde_derive 1.0.43 (registry+https://github.com/rust-lang/crates.io-index)" = "aa113e5fc4b008a626ba2bbd41330b56c9987d667f79f7b243e5a2d03d91ed1c"
+"checksum serde_derive 1.0.45 (registry+https://github.com/rust-lang/crates.io-index)" = "0409f5130e9b06444e07d4c71f55d6a2c4d1290d79faa612d9b0b540a9703fcd"
 "checksum serde_derive_internals 0.23.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9d30c4596450fd7bbda79ef15559683f9a79ac0193ea819db90000d7e1cae794"
-"checksum serde_json 1.0.16 (registry+https://github.com/rust-lang/crates.io-index)" = "8c6c4e049dc657a99e394bd85c22acbf97356feeec6dbf44150f2dcf79fb3118"
+"checksum serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f3ad6d546e765177cf3dded3c2e424a8040f870083a0e64064746b958ece9cb1"
 "checksum serde_test 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "110b3dbdf8607ec493c22d5d947753282f3bae73c0f56d322af1e8c78e4c23d5"
 "checksum smallvec 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "ee4f357e8cd37bf8822e1b964e96fd39e2cb5a0424f8aaa284ccaccc2162411c"
 "checksum state 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7345c971d1ef21ffdbd103a75990a15eb03604fc8b8852ca8cb418ee1a099028"
-"checksum syn 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "91b52877572087400e83d24b9178488541e3d535259e04ff17a63df1e5ceff59"
+"checksum syn 0.13.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90d5efaad92a0f96c629ae16302cc9591915930fd49ff0dcc6b4cde146782397"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
@@ -881,7 +881,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
-"checksum unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "51ccda9ef9efa3f7ef5d91e8f9b83bbe6955f9bf86aec89d5cce2c874625920f"
+"checksum unicode-normalization 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90d662d111b0dbb08a180f2761026cba648c258023c355954a7c00e00e354636"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f392d7819dbe58833e26872f5f6f0d68b7bbbe90fc3667e98731c4a15ad9a7ae"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "fxa-email-service"
 version = "0.1.0"
 
 [dependencies]
-config = "0.8.0"
+config = { git = "https://github.com/ivanovaleksey/config-rs", branch = "issue-70" }
 lazy_static = "1.0"
 regex = "0.2.10"
 rocket = "0.3.9"

--- a/config/default.json
+++ b/config/default.json
@@ -1,7 +1,5 @@
 {
-  "smtp": {
-    "host": "127.0.0.1",
-    "port": 25,
-    "sender": "Firefox Accounts <accounts@firefox.com>"
-  }
+  "sender": "Firefox Accounts <accounts@firefox.com>",
+  "smtp_host": "127.0.0.1",
+  "smtp_port": 25
 }

--- a/src/deserialize/mod.rs
+++ b/src/deserialize/mod.rs
@@ -1,0 +1,95 @@
+use std::fmt::{self, Display, Formatter};
+
+use regex::Regex;
+use serde::de::{Deserialize, Deserializer, Error, Unexpected};
+
+lazy_static! {
+  static ref HOST_FORMAT: Regex = Regex::new("^[A-Za-z0-9-]+(?:\\.[A-Za-z0-9-]+)*$").unwrap();
+  static ref SENDER_FORMAT: Regex = Regex::new(
+    "^[A-Za-z0-9-]+(?: [A-Za-z0-9-]+)* <[a-z0-9-]+@[a-z0-9-]+(?:\\.[a-z0-9-]+)+>$"
+  ).unwrap();
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Host(pub String);
+
+impl Host
+{
+  pub fn as_str(&self) -> &str
+  {
+    self.0.as_str()
+  }
+}
+
+impl<'d> Deserialize<'d> for Host
+{
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: Deserializer<'d>,
+  {
+    match deserialize_string(deserializer, &HOST_FORMAT, "host name or IP address") {
+      Ok(host) => Ok(Host(host)),
+      Err(error) => Err(error),
+    }
+  }
+}
+
+impl Display for Host
+{
+  fn fmt(&self, formatter: &mut Formatter) -> fmt::Result
+  {
+    write!(formatter, "{}", self.as_str())
+  }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Sender(pub String);
+
+impl Sender
+{
+  pub fn as_str(&self) -> &str
+  {
+    self.0.as_str()
+  }
+}
+
+impl<'d> Deserialize<'d> for Sender
+{
+  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+  where
+    D: Deserializer<'d>,
+  {
+    match deserialize_string(
+      deserializer,
+      &SENDER_FORMAT,
+      "sender name and email address",
+    ) {
+      Ok(sender) => Ok(Sender(sender)),
+      Err(error) => Err(error),
+    }
+  }
+}
+
+impl Display for Sender
+{
+  fn fmt(&self, formatter: &mut Formatter) -> fmt::Result
+  {
+    write!(formatter, "{}", self.as_str())
+  }
+}
+
+fn deserialize_string<'d, D>(
+  deserializer: D,
+  format: &Regex,
+  expected: &str,
+) -> Result<String, D::Error>
+where
+  D: Deserializer<'d>,
+{
+  let value: String = Deserialize::deserialize(deserializer)?;
+  if format.is_match(&value) {
+    Ok(value)
+  } else {
+    Err(D::Error::invalid_value(Unexpected::Str(&value), &expected))
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ extern crate validator;
 #[macro_use]
 extern crate validator_derive;
 
+mod deserialize;
 mod send;
 mod settings;
 

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -1,33 +1,21 @@
 use std::env;
 
 use config::{Config, ConfigError, Environment, File};
-use regex::Regex;
-use serde::de::{Error, Unexpected};
+
+use deserialize::{Host, Sender};
 
 #[cfg(test)]
 mod test;
 
-lazy_static! {
-  static ref HOST_FORMAT: Regex = Regex::new("^[A-Za-z0-9-]+(?:\\.[A-Za-z0-9-]+)*$").unwrap();
-  static ref SENDER_FORMAT: Regex = Regex::new(
-    "^[A-Za-z0-9-]+(?: [A-Za-z0-9-]+)* <[a-z0-9-]+@[a-z0-9-]+(?:\\.[a-z0-9-]+)+>$"
-  ).unwrap();
-}
-
-#[derive(Debug, Deserialize)]
-pub struct Smtp
-{
-  host: String,
-  port: u16,
-  user: Option<String>,
-  password: Option<String>,
-  sender: String,
-}
-
 #[derive(Debug, Deserialize)]
 pub struct Settings
 {
-  smtp: Smtp,
+  pub sender: Sender,
+  // HACK: Nested settings prevent the tests from creating fresh values
+  pub smtp_host: Host,
+  pub smtp_port: u16,
+  pub smtp_user: Option<String>,
+  pub smtp_password: Option<String>,
 }
 
 impl Settings
@@ -37,7 +25,7 @@ impl Settings
   ///
   /// Precedence (earlier items override later ones):
   ///
-  ///   1. Environment variables: `$FXA_<UPPERCASE_KEY_NAME>`
+  ///   1. Environment variables: `$FXA_EMAIL_<UPPERCASE_KEY_NAME>`
   ///   2. File: `config/local.json`
   ///   3. File: `config/<$NODE_ENV>.json`
   ///   4. File: `config/default.json`
@@ -60,24 +48,10 @@ impl Settings
 
     config.merge(File::with_name("config/local").required(false))?;
 
-    config.merge(Environment::with_prefix("fxa"))?;
+    config.merge(Environment::with_prefix("fxa_email"))?;
 
     match config.try_into::<Settings>() {
       Ok(settings) => {
-        if !HOST_FORMAT.is_match(&settings.smtp.host) {
-          return Err(ConfigError::invalid_value(
-            Unexpected::Str(&settings.smtp.host),
-            &"host name or IP address",
-          ));
-        }
-
-        if !SENDER_FORMAT.is_match(&settings.smtp.sender) {
-          return Err(ConfigError::invalid_value(
-            Unexpected::Str(&settings.smtp.sender),
-            &"name and email address",
-          ));
-        }
-
         // TODO: replace this with proper logging when we have it
         println!("config: {:?}", settings);
         Ok(settings)

--- a/src/settings/test.rs
+++ b/src/settings/test.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use super::*;
+use deserialize::{Host, Sender};
 
 lazy_static! {
   // HACK: mutex to prevent tests clobbering each other's environment variables
@@ -65,65 +66,71 @@ impl<'e> Drop for CleanEnvironment<'e>
 fn env_vars_take_precedence()
 {
   let _clean_env = CleanEnvironment::new(vec![
-    "FXA_SMTP_HOST",
-    "FXA_SMTP_PORT",
-    "FXA_SMTP_SENDER",
-    "FXA_SMTP_USER",
-    "FXA_SMTP_PASSWORD",
+    "FXA_EMAIL_SENDER",
+    "FXA_EMAIL_SMTP_HOST",
+    "FXA_EMAIL_SMTP_PORT",
+    "FXA_EMAIL_SMTP_USER",
+    "FXA_EMAIL_SMTP_PASSWORD",
   ]);
 
   match Settings::new() {
     Ok(settings) => {
-      let host = format!("{}{}", settings.smtp.host, "1");
-      let port = settings.smtp.port + 2;
-      let sender = format!("{}{}", "3", settings.smtp.sender);
-      let user = if let Some(ref user) = settings.smtp.user {
+      let sender = Sender(format!("{}{}", "1", settings.sender.as_str()));
+      let smtp_host = Host(format!("{}{}", settings.smtp_host.as_str(), "2"));
+      let smtp_port = settings.smtp_port + 3;
+      let smtp_user = if let Some(ref user) = settings.smtp_user {
         format!("{}{}", user, "4")
       } else {
         String::from("4")
       };
-      let password = if let Some(ref password) = settings.smtp.password {
+      let smtp_password = if let Some(ref password) = settings.smtp_password {
         format!("{}{}", password, "5")
       } else {
         String::from("5")
       };
 
-      env::set_var("FXA_SMTP_HOST", &host);
-      env::set_var("FXA_SMTP_PORT", &port.to_string());
-      env::set_var("FXA_SMTP_SENDER", &sender);
-      env::set_var("FXA_SMTP_USER", &user);
-      env::set_var("FXA_SMTP_PASSWORD", &password);
+      env::set_var("FXA_EMAIL_SENDER", sender.as_str());
+      env::set_var("FXA_EMAIL_SMTP_HOST", smtp_host.as_str());
+      env::set_var("FXA_EMAIL_SMTP_PORT", &smtp_port.to_string());
+      env::set_var("FXA_EMAIL_SMTP_USER", &smtp_user);
+      env::set_var("FXA_EMAIL_SMTP_PASSWORD", &smtp_password);
 
       match Settings::new() {
         Ok(env_settings) => {
-          assert_eq!(env_settings.smtp.host, host);
-          assert_eq!(env_settings.smtp.port, port);
-          assert_eq!(env_settings.smtp.sender, sender);
+          assert_eq!(env_settings.sender, sender);
+          assert_eq!(env_settings.smtp_host, smtp_host);
+          assert_eq!(env_settings.smtp_port, smtp_port);
 
-          if let Some(env_user) = env_settings.smtp.user {
-            assert_eq!(env_user, user);
+          if let Some(env_user) = env_settings.smtp_user {
+            assert_eq!(env_user, smtp_user);
           } else {
-            assert!(false, "smtp.user was not set");
+            assert!(false, "smtp_user was not set");
           }
 
-          if let Some(env_password) = env_settings.smtp.password {
-            assert_eq!(env_password, password);
+          if let Some(env_password) = env_settings.smtp_password {
+            assert_eq!(env_password, smtp_password);
           } else {
-            assert!(false, "smtp.password was not set");
+            assert!(false, "smtp_password was not set");
           }
         }
-        Err(error) => assert!(false, error),
+        Err(error) => {
+          println!("{}", error);
+          assert!(false);
+        }
       }
     }
-    Err(error) => assert!(false, error),
+    Err(error) => {
+      println!("{}", error);
+      assert!(false);
+    }
   }
 }
 
 #[test]
 fn invalid_host()
 {
-  let _clean_env = CleanEnvironment::new(vec!["FXA_SMTP_HOST"]);
-  env::set_var("FXA_SMTP_HOST", "https://mail.google.com/");
+  let _clean_env = CleanEnvironment::new(vec!["FXA_EMAIL_SMTP_HOST"]);
+  env::set_var("FXA_EMAIL_SMTP_HOST", "https://mail.google.com/");
 
   match Settings::new() {
     Ok(_settings) => assert!(false, "Settings::new should have failed"),
@@ -134,8 +141,8 @@ fn invalid_host()
 #[test]
 fn invalid_sender()
 {
-  let _clean_env = CleanEnvironment::new(vec!["FXA_SMTP_SENDER"]);
-  env::set_var("FXA_SMTP_SENDER", "wibble");
+  let _clean_env = CleanEnvironment::new(vec!["FXA_EMAIL_SENDER"]);
+  env::set_var("FXA_EMAIL_SENDER", "wibble");
 
   match Settings::new() {
     Ok(_settings) => assert!(false, "Settings::new should have failed"),


### PR DESCRIPTION
Fixes #13.

Extracts the inline validation code from the `settings` module to a dedicated `deserialize` module, so that the validation rules can be better re-used elsewhere.

Relies on a currently-unmerged PR in order to work, hence the `config` crate is now resolved with a git URL rather than a version string. If that situation persists, we can change it to point to a fork under our own control but hopefully it will be merged soon and we can revert to a version string. There's also an equivalent refactoring in the [`pb/deserialize-without-types` branch](https://github.com/mozilla/fxa-email-service/compare/pb/deserialize-without-types?expand=1), which doesn't require this fix but uses serde's `deserialize_with` macro instead. I'm happy to pursue that approach if it's preferable.

The other gotcha was that I had to flatten the `Settings` struct in order for the tests to be able to create clean instances with fresh values. This is a little bit annoying and is not necessary for the alternative, function-based refactoring. I don't have a root cause yet, but I'll open an issue in the appropriate repo as soon as I have a minimal test case (or come back and fix it if something's wrong here, which is eminently possible).

@mozilla/fxa-devs r?