### PR TITLE
refactor(settings): extract common functions for deserialization

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -1,7 +1,7 @@
 {
+  "sender": "Firefox Accounts <accounts@firefox.com>",
   "smtp": {
     "host": "127.0.0.1",
-    "port": 25,
-    "sender": "Firefox Accounts <accounts@firefox.com>"
+    "port": 25
   }
 }

--- a/src/deserialize/mod.rs
+++ b/src/deserialize/mod.rs
@@ -1,0 +1,39 @@
+use regex::Regex;
+use serde::de::{Deserialize, Deserializer, Error, Unexpected};
+
+lazy_static! {
+  static ref HOST_FORMAT: Regex = Regex::new("^[A-Za-z0-9-]+(?:\\.[A-Za-z0-9-]+)*$").unwrap();
+  static ref SENDER_FORMAT: Regex = Regex::new(
+    "^[A-Za-z0-9-]+(?: [A-Za-z0-9-]+)* <[a-z0-9-]+@[a-z0-9-]+(?:\\.[a-z0-9-]+)+>$"
+  ).unwrap();
+}
+
+pub fn host<'d, D>(deserializer: D) -> Result<String, D::Error>
+where
+  D: Deserializer<'d>,
+{
+  deserialize(deserializer, &HOST_FORMAT, "host name or IP address")
+}
+
+pub fn sender<'d, D>(deserializer: D) -> Result<String, D::Error>
+where
+  D: Deserializer<'d>,
+{
+  deserialize(
+    deserializer,
+    &SENDER_FORMAT,
+    "sender name and email address",
+  )
+}
+
+fn deserialize<'d, D>(deserializer: D, format: &Regex, expected: &str) -> Result<String, D::Error>
+where
+  D: Deserializer<'d>,
+{
+  let value: String = Deserialize::deserialize(deserializer)?;
+  if format.is_match(&value) {
+    Ok(value)
+  } else {
+    Err(D::Error::invalid_value(Unexpected::Str(&value), &expected))
+  }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,7 @@ extern crate validator;
 #[macro_use]
 extern crate validator_derive;
 
+mod deserialize;
 mod send;
 mod settings;
 

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -1,33 +1,28 @@
 use std::env;
 
 use config::{Config, ConfigError, Environment, File};
-use regex::Regex;
-use serde::de::{Error, Unexpected};
+
+use deserialize;
 
 #[cfg(test)]
 mod test;
 
-lazy_static! {
-  static ref HOST_FORMAT: Regex = Regex::new("^[A-Za-z0-9-]+(?:\\.[A-Za-z0-9-]+)*$").unwrap();
-  static ref SENDER_FORMAT: Regex = Regex::new(
-    "^[A-Za-z0-9-]+(?: [A-Za-z0-9-]+)* <[a-z0-9-]+@[a-z0-9-]+(?:\\.[a-z0-9-]+)+>$"
-  ).unwrap();
-}
-
 #[derive(Debug, Deserialize)]
 pub struct Smtp
 {
-  host: String,
-  port: u16,
-  user: Option<String>,
-  password: Option<String>,
-  sender: String,
+  #[serde(deserialize_with = "deserialize::host")]
+  pub host: String,
+  pub port: u16,
+  pub user: Option<String>,
+  pub password: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct Settings
 {
-  smtp: Smtp,
+  #[serde(deserialize_with = "deserialize::sender")]
+  pub sender: String,
+  pub smtp: Smtp,
 }
 
 impl Settings
@@ -37,7 +32,7 @@ impl Settings
   ///
   /// Precedence (earlier items override later ones):
   ///
-  ///   1. Environment variables: `$FXA_<UPPERCASE_KEY_NAME>`
+  ///   1. Environment variables: `$FXA_EMAIL_<UPPERCASE_KEY_NAME>`
   ///   2. File: `config/local.json`
   ///   3. File: `config/<$NODE_ENV>.json`
   ///   4. File: `config/default.json`
@@ -60,24 +55,10 @@ impl Settings
 
     config.merge(File::with_name("config/local").required(false))?;
 
-    config.merge(Environment::with_prefix("fxa"))?;
+    config.merge(Environment::with_prefix("fxa_email"))?;
 
     match config.try_into::<Settings>() {
       Ok(settings) => {
-        if !HOST_FORMAT.is_match(&settings.smtp.host) {
-          return Err(ConfigError::invalid_value(
-            Unexpected::Str(&settings.smtp.host),
-            &"host name or IP address",
-          ));
-        }
-
-        if !SENDER_FORMAT.is_match(&settings.smtp.sender) {
-          return Err(ConfigError::invalid_value(
-            Unexpected::Str(&settings.smtp.sender),
-            &"name and email address",
-          ));
-        }
-
         // TODO: replace this with proper logging when we have it
         println!("config: {:?}", settings);
         Ok(settings)


### PR DESCRIPTION
Fixes #13, opened as an alternative to #14 so that it can be r+'ed if it turns out to be the preferred option.

Extracts the inline validation code from the settings module to a dedicated deserialize module, so that the validation rules can be better re-used elsewhere.

Uses functions rather than newtype structs, for 2 reasons:

1. There's an issue in the config crate where newtype structs aren't deserialized. An unmerged PR exists to fix it, but in the meantime this changeset works round the problem.

2. With newtype structs, the tests aren't able to create fresh instances of the `Settings` struct unless it is flattened to a single level.

If we do pursue this approach, we can revisit using newtype structs down the line when both of the above are resolved.

@mozilla/fxa-devs r?