### PR TITLE
fix(db): add missing fields/values to auth_db::BounceRecord

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,11 +95,11 @@ dependencies = [
 
 [[package]]
 name = "card-validate"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -129,7 +129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nom 3.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde-hjson 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -158,7 +158,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -166,7 +166,7 @@ name = "core-foundation-sys"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -323,14 +323,14 @@ dependencies = [
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket_codegen 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket_contrib 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_codegen 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_contrib 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_core 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_credential 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_ses 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "validator 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "validator_derive 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -446,7 +446,7 @@ name = "iovec"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -456,8 +456,8 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -497,7 +497,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.40"
+version = "0.2.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -550,7 +550,7 @@ name = "memchr"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -558,7 +558,7 @@ name = "memchr"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -566,7 +566,7 @@ name = "memchr"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -611,7 +611,7 @@ dependencies = [
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -636,7 +636,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "schannel 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "security-framework 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -650,7 +650,7 @@ version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -693,7 +693,7 @@ name = "num_cpus"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -704,17 +704,17 @@ dependencies = [
  "bitflags 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "openssl-sys 0.9.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-sys 0.9.31 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.30"
+version = "0.9.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -792,6 +792,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "quote"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -800,12 +808,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "quote"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rand"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -815,7 +831,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -834,14 +850,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.37"
+version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -931,7 +947,7 @@ dependencies = [
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 2.0.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_urlencoded 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -948,14 +964,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rocket"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -979,23 +995,23 @@ dependencies = [
 
 [[package]]
 name = "rocket_codegen"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "yansi 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rocket_contrib"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1014,7 +1030,7 @@ dependencies = [
  "log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_credential 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1087,7 +1103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "security-framework-sys 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1097,7 +1113,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1120,7 +1136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "serde"
-version = "1.0.55"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1137,12 +1153,12 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.55"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.13.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1152,7 +1168,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1170,7 +1186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1217,11 +1233,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "syn"
-version = "0.13.10"
+version = "0.13.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1245,7 +1271,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1270,8 +1296,8 @@ name = "time"
 version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1440,7 +1466,7 @@ name = "toml"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "serde 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1548,12 +1574,12 @@ name = "validator"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "card-validate 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "card-validate 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1565,7 +1591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "if_chain 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.13.10 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "validator 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1668,7 +1694,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "74c0b906e9446b0a2e4f760cdb3fa4b2c48cdc6db8766a845c54b6ff063fd2e9"
 "checksum bytes 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "2f1d50c876fb7545f5f289cd8b2aee3f359d073ae819eed5d6373638e2c61e59"
-"checksum card-validate 2.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "377e2cbab679f09143661a24262602f6f5e0fb20d164b464c0fc25c4268937c9"
+"checksum card-validate 2.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "42e836d5f9e13fabd2b181cc133bc007d1b53851fd3e897ce1dd759bde0fd871"
 "checksum cc 1.0.15 (registry+https://github.com/rust-lang/crates.io-index)" = "0ebb87d1116151416c0cf66a0e3fb6430cccd120fd6300794b4dfaa050ac40ba"
 "checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
 "checksum chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1cce36c92cb605414e9b824f866f5babe0a0368e39ea07393b9b63cf3844c0e6"
@@ -1713,7 +1739,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum lazycell 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a6f08839bc70ef4a3fe1d566d5350f519c5912ea86be0df1740a7d247c7fc0ef"
-"checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
+"checksum libc 0.2.41 (registry+https://github.com/rust-lang/crates.io-index)" = "ac8ebf8343a981e2fa97042b14768f02ed3e1d602eac06cae6166df3c8ced206"
 "checksum libflate 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "1a429b86418868c7ea91ee50e9170683f47fd9d94f5375438ec86ec3adb74e8e"
 "checksum linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd"
 "checksum linked-hash-map 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "70fb39025bc7cdd76305867c4eccf2f2dcf6e9a57f5b21a93e1c2d86cd03ec9e"
@@ -1738,7 +1764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num-traits 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "775393e285254d2f5004596d69bb8bc1149754570dcc08cf30cabeba67955e28"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "a3605c298474a3aa69de92d21139fb5e2a81688d308262359d85cdd0d12a7985"
-"checksum openssl-sys 0.9.30 (registry+https://github.com/rust-lang/crates.io-index)" = "73ae718c3562989cd3a0a5c26610feca02f8116822f6f195e6cf4887481e57f5"
+"checksum openssl-sys 0.9.31 (registry+https://github.com/rust-lang/crates.io-index)" = "a4d6a27d108b29befe1822d40e2e22f85518dac59acbf7f30fdc532f48fd0a77"
 "checksum ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b81cf3b8cb96aa0e73bbedfcdc9708d09fec2854ba8d474be4e6f666d7379e8b"
 "checksum pear 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "2d0b966f9b387335fedc3546471db37b6e02430c180878015df1eaa3e62da289"
 "checksum pear_codegen 0.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "3a97c944f71801ef6b36bbf47a98b24167795d74bb8678f013d60d312bfc795c"
@@ -1749,12 +1775,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum phf_shared 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)" = "c2261d544c2bb6aa3b10022b0be371b9c7c64f762ef28c6f5d4f1ef6d97b5930"
 "checksum pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "110d5ee3593dbb73f56294327fe5668bcc997897097cbc76b51e7aed3f52452f"
 "checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
+"checksum proc-macro2 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a45f2f0ae0b5757f6fe9e68745ba25f5246aea3598984ed81d013865873c1f84"
 "checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
+"checksum quote 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9e53eeda07ddbd8b057dde66d9beded11d0dfda13f0db0769e6b71d6bcf2074e"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum rayon 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a77c51c07654ddd93f6cb543c7a849863b03abc7e82591afda6dc8ad4ac3ac4a"
 "checksum rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d24ad214285a7729b174ed6d3bcfcb80177807f959d95fafd5bfc5c4f201ac8"
-"checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
+"checksum redox_syscall 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "0a12d51a5b5fd700e6c757f15877685bfa04fd7eb60c108f01d045cafa0073c2"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
 "checksum regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
 "checksum regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "75ecf88252dce580404a22444fc7d626c01815debba56a7f4f536772a5ff19d3"
@@ -1765,9 +1793,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum reqwest 0.8.5 (registry+https://github.com/rust-lang/crates.io-index)" = "241faa9a8ca28a03cbbb9815a5d085f271d4c0168a19181f106aa93240c22ddb"
 "checksum ring 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2a6dc7fc06a05e6de183c5b97058582e9da2de0c136eafe49609769c507724"
-"checksum rocket 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)" = "96ce1f13d632f010c0214552255c1d3f8985c2ba08403ef5e52bcd69b73b73a2"
-"checksum rocket_codegen 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)" = "41ca0be1954323a1214f009b134c1d4f647e4ebe5b84c3941520d0bf0d459603"
-"checksum rocket_contrib 0.3.10 (registry+https://github.com/rust-lang/crates.io-index)" = "feed64efcb799c295d862da9f9e3850ad6e1894eaf69a7f49315d1634b1641e2"
+"checksum rocket 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "46002c78d93f9272d59ffb24ded4ad90782ef203e9eac635d1f150ca5a88b87f"
+"checksum rocket_codegen 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "63686b070f0520a93e98ce169e517d6218d1210cc98c066f9ccf120ad05199c9"
+"checksum rocket_contrib 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "243a018305a2a2c1b26e60e6a9240f94f3f82e5c7a203fc2edf042e4977c77e6"
 "checksum rusoto_core 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12daaa6d62d64f6447bf0299ce775f4e05f8e75e5418e817da094b9de04ad22d"
 "checksum rusoto_credential 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "53199d09fd1b7d4f5ac50f4d23106577624238ea77cae2b44eb1d1fc4cd956a4"
 "checksum rusoto_ses 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "88d4645c94b099369602db7d814b1741f991b3d6821d8076b2ac67824b8cc130"
@@ -1781,9 +1809,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "9dad3f759919b92c3068c696c15c3d17238234498bbdcc80f2c469606f948ac8"
-"checksum serde 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)" = "97f6a6c3caba0cf8f883b53331791036404ce3c1bd895961cf8bb2f8cecfd84b"
+"checksum serde 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)" = "2a4d976362a13caad61c38cf841401d2d4d480496a9391c3842c288b01f9de95"
 "checksum serde-hjson 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7a2376ebb8976138927f48b49588ef73cde2f6591b8b3df22f4063e0f27b9bec"
-"checksum serde_derive 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)" = "f51b0ef935cf8a41a77bce553da1f8751a739b7ad82dd73669475a22e6ecedb0"
+"checksum serde_derive 1.0.59 (registry+https://github.com/rust-lang/crates.io-index)" = "94bb618afe46430c6b089e9b111dc5b2fcd3e26a268da0993f6d16bea51c6021"
 "checksum serde_json 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)" = "f3ad6d546e765177cf3dded3c2e424a8040f870083a0e64064746b958ece9cb1"
 "checksum serde_test 0.8.23 (registry+https://github.com/rust-lang/crates.io-index)" = "110b3dbdf8607ec493c22d5d947753282f3bae73c0f56d322af1e8c78e4c23d5"
 "checksum serde_urlencoded 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e703cef904312097cfceab9ce131ff6bbe09e8c964a0703345a5f49238757bc1"
@@ -1794,7 +1822,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c8cbcd6df1e117c2210e13ab5109635ad68a929fcbb8964dc965b76cb5ee013"
 "checksum smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03dab98ab5ded3a8b43b2c80751194608d0b2aa0f1d46cf95d1c35e192844aa7"
 "checksum state 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7345c971d1ef21ffdbd103a75990a15eb03604fc8b8852ca8cb418ee1a099028"
-"checksum syn 0.13.10 (registry+https://github.com/rust-lang/crates.io-index)" = "77961dcdac942fa8bc033c16f3a790b311c8a27d00811b878ebd8cf9b7ba39d5"
+"checksum syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)" = "14f9bf6292f3a61d2c716723fdb789a41bbe104168e6f496dc6497e531ea1b9b"
+"checksum syn 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)" = "99d991a9e7c33123925e511baab68f7ec25c3795962fe326a2395e5a42a614f0"
 "checksum take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"

--- a/src/auth_db/mod.rs
+++ b/src/auth_db/mod.rs
@@ -114,6 +114,7 @@ impl From<RequestError> for DbError {
     }
 }
 
+#[derive(Debug)]
 struct DbUrls {
     get_email_bounces: Url,
 }
@@ -135,6 +136,7 @@ pub trait Db {
     fn get_email_bounces(&self, address: &str) -> Result<Vec<BounceRecord>, DbError>;
 }
 
+#[derive(Debug)]
 pub struct DbClient {
     urls: DbUrls,
     request_client: RequestClient,

--- a/src/auth_db/mod.rs
+++ b/src/auth_db/mod.rs
@@ -8,23 +8,73 @@ use std::{
 
 use hex;
 use reqwest::{Client as RequestClient, Error as RequestError, StatusCode, Url, UrlError};
+use serde::de::{Deserialize, Deserializer, Error as DeserializeError, Unexpected};
 
 use settings::Settings;
 
 #[cfg(test)]
 mod test;
 
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum BounceType {
-    Hard = 1,
-    Soft = 2,
-    Complaint = 3,
+    Hard,
+    Soft,
+    Complaint,
+}
+
+impl<'d> Deserialize<'d> for BounceType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'d>,
+    {
+        let value: u8 = Deserialize::deserialize(deserializer)?;
+        match value {
+            // The auth db falls back to zero when it receives a value it doesn't recognise
+            0 => {
+                println!("Mapped default auth db bounce type to BounceType::Soft");
+                Ok(BounceType::Soft)
+            }
+            1 => Ok(BounceType::Hard),
+            2 => Ok(BounceType::Soft),
+            3 => Ok(BounceType::Complaint),
+            _ => Err(D::Error::invalid_value(
+                Unexpected::Unsigned(value as u64),
+                &"bounce type",
+            )),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Deserialize)]
+pub enum BounceSubtype {
+    // Set by the auth db if an input string is not recognised
+    Unmapped = 0,
+    // These are mapped from the equivalent SES bounceSubType values
+    Undetermined = 1,
+    General = 2,
+    NoEmail = 3,
+    Suppressed = 4,
+    MailboxFull = 5,
+    MessageTooLarge = 6,
+    ContentRejected = 7,
+    AttachmentRejected = 8,
+    // These are mapped from the equivalent SES complaintFeedbackType values
+    Abuse = 9,
+    AuthFailure = 10,
+    Fraud = 11,
+    NotSpam = 12,
+    Other = 13,
+    Virus = 14,
+}
+
+#[derive(Clone, Debug, Deserialize)]
 pub struct BounceRecord {
+    #[serde(rename = "email")]
+    pub address: String,
     #[serde(rename = "bounceType")]
     pub bounce_type: BounceType,
+    #[serde(rename = "bounceSubType")]
+    pub bounce_subtype: BounceSubtype,
     #[serde(rename = "createdAt")]
     pub created_at: u64,
 }

--- a/src/auth_db/mod.rs
+++ b/src/auth_db/mod.rs
@@ -116,24 +116,24 @@ impl From<RequestError> for DbError {
 
 #[derive(Debug)]
 struct DbUrls {
-    get_email_bounces: Url,
+    get_bounces: Url,
 }
 
 impl DbUrls {
     pub fn new(settings: &Settings) -> DbUrls {
         let base_uri: Url = settings.authdb.baseuri.parse().expect("invalid base URI");
         DbUrls {
-            get_email_bounces: base_uri.join("emailBounces/").expect("invalid base URI"),
+            get_bounces: base_uri.join("emailBounces/").expect("invalid base URI"),
         }
     }
 
-    pub fn get_email_bounces(&self, address: &str) -> Result<Url, UrlError> {
-        self.get_email_bounces.join(&hex::encode(address))
+    pub fn get_bounces(&self, address: &str) -> Result<Url, UrlError> {
+        self.get_bounces.join(&hex::encode(address))
     }
 }
 
 pub trait Db {
-    fn get_email_bounces(&self, address: &str) -> Result<Vec<BounceRecord>, DbError>;
+    fn get_bounces(&self, address: &str) -> Result<Vec<BounceRecord>, DbError>;
 }
 
 #[derive(Debug)]
@@ -152,10 +152,10 @@ impl DbClient {
 }
 
 impl Db for DbClient {
-    fn get_email_bounces(&self, address: &str) -> Result<Vec<BounceRecord>, DbError> {
+    fn get_bounces(&self, address: &str) -> Result<Vec<BounceRecord>, DbError> {
         let mut response = self
             .request_client
-            .get(self.urls.get_email_bounces(address)?)
+            .get(self.urls.get_bounces(address)?)
             .send()?;
         match response.status() {
             StatusCode::Ok => response.json::<Vec<BounceRecord>>().map_err(From::from),

--- a/src/auth_db/test.rs
+++ b/src/auth_db/test.rs
@@ -7,20 +7,20 @@ use serde_json;
 use super::*;
 
 #[test]
-fn get_email_bounces() {
+fn get_bounces() {
     let settings = Settings::new().expect("config error");
     let db = DbClient::new(&settings);
-    if let Err(error) = db.get_email_bounces("foo@example.com") {
+    if let Err(error) = db.get_bounces("foo@example.com") {
         assert!(false, error.description().to_string());
     }
 }
 
 #[test]
-fn get_email_bounces_invalid_address() {
+fn get_bounces_invalid_address() {
     let settings = Settings::new().expect("config error");
     let db = DbClient::new(&settings);
-    match db.get_email_bounces("") {
-        Ok(_) => assert!(false, "DbClient::get_email_bounces should have failed"),
+    match db.get_bounces("") {
+        Ok(_) => assert!(false, "DbClient::get_bounces should have failed"),
         Err(error) => assert_eq!(error.description(), "auth db response: 400 Bad Request"),
     }
 }

--- a/src/auth_db/test.rs
+++ b/src/auth_db/test.rs
@@ -2,6 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 
+use serde_json;
+
 use super::*;
 
 #[test]
@@ -20,5 +22,29 @@ fn get_email_bounces_invalid_address() {
     match db.get_email_bounces("") {
         Ok(_) => assert!(false, "DbClient::get_email_bounces should have failed"),
         Err(error) => assert_eq!(error.description(), "auth db response: 400 Bad Request"),
+    }
+}
+
+#[test]
+fn deserialize_bounce_type() {
+    let bounce_type: BounceType = serde_json::from_value(json!(0)).expect("JSON error");
+    assert_eq!(bounce_type, BounceType::Soft);
+    let bounce_type: BounceType = serde_json::from_value(json!(1)).expect("JSON error");
+    assert_eq!(bounce_type, BounceType::Hard);
+    let bounce_type: BounceType = serde_json::from_value(json!(2)).expect("JSON error");
+    assert_eq!(bounce_type, BounceType::Soft);
+    let bounce_type: BounceType = serde_json::from_value(json!(3)).expect("JSON error");
+    assert_eq!(bounce_type, BounceType::Complaint);
+}
+
+#[test]
+fn deserialize_invalid_bounce_type() {
+    match serde_json::from_value::<BounceType>(json!(4)) {
+        Ok(_) => assert!(false, "serde_json::from_value should have failed"),
+        Err(error) => assert_eq!(error.description(), "JSON error"),
+    }
+    match serde_json::from_value::<BounceType>(json!(-1)) {
+        Ok(_) => assert!(false, "serde_json::from_value should have failed"),
+        Err(error) => assert_eq!(error.description(), "JSON error"),
     }
 }

--- a/src/bounces/mod.rs
+++ b/src/bounces/mod.rs
@@ -22,7 +22,7 @@ pub struct BounceError {
 }
 
 impl BounceError {
-    pub fn new(address: &str, bounce: BounceRecord) -> BounceError {
+    pub fn new(address: &str, bounce: &BounceRecord) -> BounceError {
         let description = format!(
             "email address violated {} limit",
             match bounce.bounce_type {
@@ -34,7 +34,7 @@ impl BounceError {
 
         BounceError {
             address: address.to_string(),
-            bounce: Some(bounce),
+            bounce: Some(bounce.clone()),
             description,
         }
     }
@@ -101,7 +101,7 @@ impl<'a> Bounces<'a> {
                         BounceType::Complaint => &self.limits.complaint,
                     };
                     if is_bounce_violation(*count, bounce.created_at, now, limits) {
-                        return Err(BounceError::new(address, *bounce));
+                        return Err(BounceError::new(address, bounce));
                     }
                 }
 

--- a/src/bounces/mod.rs
+++ b/src/bounces/mod.rs
@@ -84,7 +84,7 @@ impl<'a> Bounces<'a> {
     }
 
     pub fn check(&self, address: &str) -> Result<(), BounceError> {
-        let bounces = self.db.get_email_bounces(address)?;
+        let bounces = self.db.get_bounces(address)?;
         let now = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .expect("system time error");

--- a/src/bounces/test.rs
+++ b/src/bounces/test.rs
@@ -5,7 +5,7 @@
 use serde_json::{self, Value as Json};
 
 use super::*;
-use auth_db::{Db, DbError};
+use auth_db::{BounceSubtype, BounceType, Db, DbError};
 use settings::Settings;
 
 const SECOND: u64 = 1000;
@@ -49,15 +49,21 @@ impl Db for DbMockNoBounce {
         let now = now_as_milliseconds();
         Ok(vec![
             BounceRecord {
+                address: String::from("foo@example.com"),
                 bounce_type: BounceType::Soft,
+                bounce_subtype: BounceSubtype::Undetermined,
                 created_at: now - DAY - 1,
             },
             BounceRecord {
+                address: String::from("foo@example.com"),
                 bounce_type: BounceType::Hard,
+                bounce_subtype: BounceSubtype::Undetermined,
                 created_at: now - WEEK - 1,
             },
             BounceRecord {
+                address: String::from("foo@example.com"),
                 bounce_type: BounceType::Complaint,
+                bounce_subtype: BounceSubtype::Undetermined,
                 created_at: now - MONTH - 1,
             },
         ])
@@ -106,7 +112,9 @@ impl Db for DbMockBounceSoft {
     fn get_email_bounces(&self, _address: &str) -> Result<Vec<BounceRecord>, DbError> {
         let now = now_as_milliseconds();
         Ok(vec![BounceRecord {
+            address: String::from("foo@example.com"),
             bounce_type: BounceType::Soft,
+            bounce_subtype: BounceSubtype::Undetermined,
             created_at: now - DAY + SECOND * 2,
         }])
     }
@@ -147,7 +155,9 @@ impl Db for DbMockBounceHard {
     fn get_email_bounces(&self, _address: &str) -> Result<Vec<BounceRecord>, DbError> {
         let now = now_as_milliseconds();
         Ok(vec![BounceRecord {
+            address: String::from("bar@example.com"),
             bounce_type: BounceType::Hard,
+            bounce_subtype: BounceSubtype::Undetermined,
             created_at: now - WEEK + SECOND * 2,
         }])
     }
@@ -188,7 +198,9 @@ impl Db for DbMockComplaint {
     fn get_email_bounces(&self, _address: &str) -> Result<Vec<BounceRecord>, DbError> {
         let now = now_as_milliseconds();
         Ok(vec![BounceRecord {
+            address: String::from("baz@example.com"),
             bounce_type: BounceType::Complaint,
+            bounce_subtype: BounceSubtype::Undetermined,
             created_at: now - MONTH + SECOND * 2,
         }])
     }
@@ -258,39 +270,57 @@ impl Db for DbMockNoBounceWithNonZeroLimits {
         let now = now_as_milliseconds();
         Ok(vec![
             BounceRecord {
+                address: String::from("foo@example.com"),
                 bounce_type: BounceType::Soft,
+                bounce_subtype: BounceSubtype::Undetermined,
                 created_at: now - DAY + MINUTE,
             },
             BounceRecord {
+                address: String::from("foo@example.com"),
                 bounce_type: BounceType::Hard,
+                bounce_subtype: BounceSubtype::Undetermined,
                 created_at: now - WEEK + MINUTE,
             },
             BounceRecord {
+                address: String::from("foo@example.com"),
                 bounce_type: BounceType::Complaint,
+                bounce_subtype: BounceSubtype::Undetermined,
                 created_at: now - MONTH + MINUTE,
             },
             BounceRecord {
+                address: String::from("foo@example.com"),
                 bounce_type: BounceType::Soft,
+                bounce_subtype: BounceSubtype::Undetermined,
                 created_at: now - DAY + SECOND * 2,
             },
             BounceRecord {
+                address: String::from("foo@example.com"),
                 bounce_type: BounceType::Hard,
+                bounce_subtype: BounceSubtype::Undetermined,
                 created_at: now - WEEK + SECOND * 2,
             },
             BounceRecord {
+                address: String::from("foo@example.com"),
                 bounce_type: BounceType::Complaint,
+                bounce_subtype: BounceSubtype::Undetermined,
                 created_at: now - MONTH + SECOND * 2,
             },
             BounceRecord {
+                address: String::from("foo@example.com"),
                 bounce_type: BounceType::Soft,
+                bounce_subtype: BounceSubtype::Undetermined,
                 created_at: now - DAY - 1,
             },
             BounceRecord {
+                address: String::from("foo@example.com"),
                 bounce_type: BounceType::Hard,
+                bounce_subtype: BounceSubtype::Undetermined,
                 created_at: now - WEEK - 1,
             },
             BounceRecord {
+                address: String::from("foo@example.com"),
                 bounce_type: BounceType::Complaint,
+                bounce_subtype: BounceSubtype::Undetermined,
                 created_at: now - MONTH - 1,
             },
         ])
@@ -335,19 +365,27 @@ impl Db for DbMockBounceWithMultipleLimits {
         let now = now_as_milliseconds();
         Ok(vec![
             BounceRecord {
+                address: String::from("foo@example.com"),
                 bounce_type: BounceType::Soft,
+                bounce_subtype: BounceSubtype::Undetermined,
                 created_at: now - SECOND * 4,
             },
             BounceRecord {
+                address: String::from("foo@example.com"),
                 bounce_type: BounceType::Soft,
+                bounce_subtype: BounceSubtype::Undetermined,
                 created_at: now - MINUTE * 2 + SECOND * 4,
             },
             BounceRecord {
+                address: String::from("foo@example.com"),
                 bounce_type: BounceType::Soft,
+                bounce_subtype: BounceSubtype::Undetermined,
                 created_at: now - MINUTE * 2 + SECOND * 3,
             },
             BounceRecord {
+                address: String::from("foo@example.com"),
                 bounce_type: BounceType::Soft,
+                bounce_subtype: BounceSubtype::Undetermined,
                 created_at: now - MINUTE * 2 + SECOND * 2,
             },
         ])

--- a/src/bounces/test.rs
+++ b/src/bounces/test.rs
@@ -45,7 +45,7 @@ fn create_settings(bounce_limits: Json) -> Settings {
 pub struct DbMockNoBounce;
 
 impl Db for DbMockNoBounce {
-    fn get_email_bounces(&self, _address: &str) -> Result<Vec<BounceRecord>, DbError> {
+    fn get_bounces(&self, _address: &str) -> Result<Vec<BounceRecord>, DbError> {
         let now = now_as_milliseconds();
         Ok(vec![
             BounceRecord {
@@ -109,7 +109,7 @@ fn check_soft_bounce() {
 pub struct DbMockBounceSoft;
 
 impl Db for DbMockBounceSoft {
-    fn get_email_bounces(&self, _address: &str) -> Result<Vec<BounceRecord>, DbError> {
+    fn get_bounces(&self, _address: &str) -> Result<Vec<BounceRecord>, DbError> {
         let now = now_as_milliseconds();
         Ok(vec![BounceRecord {
             address: String::from("foo@example.com"),
@@ -152,7 +152,7 @@ fn check_hard_bounce() {
 pub struct DbMockBounceHard;
 
 impl Db for DbMockBounceHard {
-    fn get_email_bounces(&self, _address: &str) -> Result<Vec<BounceRecord>, DbError> {
+    fn get_bounces(&self, _address: &str) -> Result<Vec<BounceRecord>, DbError> {
         let now = now_as_milliseconds();
         Ok(vec![BounceRecord {
             address: String::from("bar@example.com"),
@@ -195,7 +195,7 @@ fn check_complaint() {
 pub struct DbMockComplaint;
 
 impl Db for DbMockComplaint {
-    fn get_email_bounces(&self, _address: &str) -> Result<Vec<BounceRecord>, DbError> {
+    fn get_bounces(&self, _address: &str) -> Result<Vec<BounceRecord>, DbError> {
         let now = now_as_milliseconds();
         Ok(vec![BounceRecord {
             address: String::from("baz@example.com"),
@@ -237,7 +237,7 @@ fn check_db_error() {
 pub struct DbMockError;
 
 impl Db for DbMockError {
-    fn get_email_bounces(&self, _address: &str) -> Result<Vec<BounceRecord>, DbError> {
+    fn get_bounces(&self, _address: &str) -> Result<Vec<BounceRecord>, DbError> {
         Err(DbError::new(String::from("wibble blee")))
     }
 }
@@ -266,7 +266,7 @@ fn check_no_bounces_with_nonzero_limits() {
 pub struct DbMockNoBounceWithNonZeroLimits;
 
 impl Db for DbMockNoBounceWithNonZeroLimits {
-    fn get_email_bounces(&self, _address: &str) -> Result<Vec<BounceRecord>, DbError> {
+    fn get_bounces(&self, _address: &str) -> Result<Vec<BounceRecord>, DbError> {
         let now = now_as_milliseconds();
         Ok(vec![
             BounceRecord {
@@ -361,7 +361,7 @@ fn check_bounce_with_multiple_limits() {
 pub struct DbMockBounceWithMultipleLimits;
 
 impl Db for DbMockBounceWithMultipleLimits {
-    fn get_email_bounces(&self, _address: &str) -> Result<Vec<BounceRecord>, DbError> {
+    fn get_bounces(&self, _address: &str) -> Result<Vec<BounceRecord>, DbError> {
         let now = now_as_milliseconds();
         Ok(vec![
             BounceRecord {


### PR DESCRIPTION
When I did #22, I didn't pay much attention to the `emailBounces` table because there weren't any rows in my table locally. But it quickly became obvious while implementing #5 that I was missing some columns as well as a valid value for the `BounceType` enum.

This changeset fixes both of those issues and includes a couple of other nearby tweaks taken from the same branch, so that I can bring the size of that PR down a bit (it's a beast).

@mozilla/fxa-devs r?