### PR TITLE
fix(db): fix broken BounceSubtype deserialization

### DIFF
--- a/src/auth_db/mod.rs
+++ b/src/auth_db/mod.rs
@@ -45,26 +45,56 @@ impl<'d> Deserialize<'d> for BounceType {
     }
 }
 
-#[derive(Clone, Copy, Debug, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum BounceSubtype {
     // Set by the auth db if an input string is not recognised
-    Unmapped = 0,
+    Unmapped,
     // These are mapped from the equivalent SES bounceSubType values
-    Undetermined = 1,
-    General = 2,
-    NoEmail = 3,
-    Suppressed = 4,
-    MailboxFull = 5,
-    MessageTooLarge = 6,
-    ContentRejected = 7,
-    AttachmentRejected = 8,
+    Undetermined,
+    General,
+    NoEmail,
+    Suppressed,
+    MailboxFull,
+    MessageTooLarge,
+    ContentRejected,
+    AttachmentRejected,
     // These are mapped from the equivalent SES complaintFeedbackType values
-    Abuse = 9,
-    AuthFailure = 10,
-    Fraud = 11,
-    NotSpam = 12,
-    Other = 13,
-    Virus = 14,
+    Abuse,
+    AuthFailure,
+    Fraud,
+    NotSpam,
+    Other,
+    Virus,
+}
+
+impl<'d> Deserialize<'d> for BounceSubtype {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'d>,
+    {
+        let value: u8 = Deserialize::deserialize(deserializer)?;
+        match value {
+            0 => Ok(BounceSubtype::Unmapped),
+            1 => Ok(BounceSubtype::Undetermined),
+            2 => Ok(BounceSubtype::General),
+            3 => Ok(BounceSubtype::NoEmail),
+            4 => Ok(BounceSubtype::Suppressed),
+            5 => Ok(BounceSubtype::MailboxFull),
+            6 => Ok(BounceSubtype::MessageTooLarge),
+            7 => Ok(BounceSubtype::ContentRejected),
+            8 => Ok(BounceSubtype::AttachmentRejected),
+            9 => Ok(BounceSubtype::Abuse),
+            10 => Ok(BounceSubtype::AuthFailure),
+            11 => Ok(BounceSubtype::Fraud),
+            12 => Ok(BounceSubtype::NotSpam),
+            13 => Ok(BounceSubtype::Other),
+            14 => Ok(BounceSubtype::Virus),
+            _ => Err(D::Error::invalid_value(
+                Unexpected::Unsigned(value as u64),
+                &"bounce subtype",
+            )),
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/src/auth_db/test.rs
+++ b/src/auth_db/test.rs
@@ -7,6 +7,76 @@ use serde_json;
 use super::*;
 
 #[test]
+fn deserialize_bounce_type() {
+    let bounce_type: BounceType = serde_json::from_value(From::from(0)).expect("JSON error");
+    assert_eq!(bounce_type, BounceType::Soft);
+    let bounce_type: BounceType = serde_json::from_value(From::from(1)).expect("JSON error");
+    assert_eq!(bounce_type, BounceType::Hard);
+    let bounce_type: BounceType = serde_json::from_value(From::from(2)).expect("JSON error");
+    assert_eq!(bounce_type, BounceType::Soft);
+    let bounce_type: BounceType = serde_json::from_value(From::from(3)).expect("JSON error");
+    assert_eq!(bounce_type, BounceType::Complaint);
+}
+
+#[test]
+fn deserialize_invalid_bounce_type() {
+    match serde_json::from_value::<BounceType>(From::from(4)) {
+        Ok(_) => assert!(false, "serde_json::from_value should have failed"),
+        Err(error) => assert_eq!(error.description(), "JSON error"),
+    }
+    match serde_json::from_value::<BounceType>(From::from(-1)) {
+        Ok(_) => assert!(false, "serde_json::from_value should have failed"),
+        Err(error) => assert_eq!(error.description(), "JSON error"),
+    }
+}
+
+#[test]
+fn deserialize_bounce_subtype() {
+    let bounce_type: BounceSubtype = serde_json::from_value(From::from(0)).expect("JSON error");
+    assert_eq!(bounce_type, BounceSubtype::Unmapped);
+    let bounce_type: BounceSubtype = serde_json::from_value(From::from(1)).expect("JSON error");
+    assert_eq!(bounce_type, BounceSubtype::Undetermined);
+    let bounce_type: BounceSubtype = serde_json::from_value(From::from(2)).expect("JSON error");
+    assert_eq!(bounce_type, BounceSubtype::General);
+    let bounce_type: BounceSubtype = serde_json::from_value(From::from(3)).expect("JSON error");
+    assert_eq!(bounce_type, BounceSubtype::NoEmail);
+    let bounce_type: BounceSubtype = serde_json::from_value(From::from(4)).expect("JSON error");
+    assert_eq!(bounce_type, BounceSubtype::Suppressed);
+    let bounce_type: BounceSubtype = serde_json::from_value(From::from(5)).expect("JSON error");
+    assert_eq!(bounce_type, BounceSubtype::MailboxFull);
+    let bounce_type: BounceSubtype = serde_json::from_value(From::from(6)).expect("JSON error");
+    assert_eq!(bounce_type, BounceSubtype::MessageTooLarge);
+    let bounce_type: BounceSubtype = serde_json::from_value(From::from(7)).expect("JSON error");
+    assert_eq!(bounce_type, BounceSubtype::ContentRejected);
+    let bounce_type: BounceSubtype = serde_json::from_value(From::from(8)).expect("JSON error");
+    assert_eq!(bounce_type, BounceSubtype::AttachmentRejected);
+    let bounce_type: BounceSubtype = serde_json::from_value(From::from(9)).expect("JSON error");
+    assert_eq!(bounce_type, BounceSubtype::Abuse);
+    let bounce_type: BounceSubtype = serde_json::from_value(From::from(10)).expect("JSON error");
+    assert_eq!(bounce_type, BounceSubtype::AuthFailure);
+    let bounce_type: BounceSubtype = serde_json::from_value(From::from(11)).expect("JSON error");
+    assert_eq!(bounce_type, BounceSubtype::Fraud);
+    let bounce_type: BounceSubtype = serde_json::from_value(From::from(12)).expect("JSON error");
+    assert_eq!(bounce_type, BounceSubtype::NotSpam);
+    let bounce_type: BounceSubtype = serde_json::from_value(From::from(13)).expect("JSON error");
+    assert_eq!(bounce_type, BounceSubtype::Other);
+    let bounce_type: BounceSubtype = serde_json::from_value(From::from(14)).expect("JSON error");
+    assert_eq!(bounce_type, BounceSubtype::Virus);
+}
+
+#[test]
+fn deserialize_invalid_bounce_subtype() {
+    match serde_json::from_value::<BounceSubtype>(From::from(15)) {
+        Ok(_) => assert!(false, "serde_json::from_value should have failed"),
+        Err(error) => assert_eq!(error.description(), "JSON error"),
+    }
+    match serde_json::from_value::<BounceSubtype>(From::from(-1)) {
+        Ok(_) => assert!(false, "serde_json::from_value should have failed"),
+        Err(error) => assert_eq!(error.description(), "JSON error"),
+    }
+}
+
+#[test]
 fn get_bounces() {
     let settings = Settings::new().expect("config error");
     let db = DbClient::new(&settings);
@@ -22,29 +92,5 @@ fn get_bounces_invalid_address() {
     match db.get_bounces("") {
         Ok(_) => assert!(false, "DbClient::get_bounces should have failed"),
         Err(error) => assert_eq!(error.description(), "auth db response: 400 Bad Request"),
-    }
-}
-
-#[test]
-fn deserialize_bounce_type() {
-    let bounce_type: BounceType = serde_json::from_value(json!(0)).expect("JSON error");
-    assert_eq!(bounce_type, BounceType::Soft);
-    let bounce_type: BounceType = serde_json::from_value(json!(1)).expect("JSON error");
-    assert_eq!(bounce_type, BounceType::Hard);
-    let bounce_type: BounceType = serde_json::from_value(json!(2)).expect("JSON error");
-    assert_eq!(bounce_type, BounceType::Soft);
-    let bounce_type: BounceType = serde_json::from_value(json!(3)).expect("JSON error");
-    assert_eq!(bounce_type, BounceType::Complaint);
-}
-
-#[test]
-fn deserialize_invalid_bounce_type() {
-    match serde_json::from_value::<BounceType>(json!(4)) {
-        Ok(_) => assert!(false, "serde_json::from_value should have failed"),
-        Err(error) => assert_eq!(error.description(), "JSON error"),
-    }
-    match serde_json::from_value::<BounceType>(json!(-1)) {
-        Ok(_) => assert!(false, "serde_json::from_value should have failed"),
-        Err(error) => assert_eq!(error.description(), "JSON error"),
     }
 }


### PR DESCRIPTION
Extracted from #28.

I was missing some tests for `BounceSubtype` deserialization, which meant I hadn't realised that the derived implementation of `Deserialize` was mapping values to strings rather than numbers. This change fixes that and adds the corresponding test coverage.

@mozilla/fxa-devs r?