### PR TITLE
fix(errors): include more useful messages in wrapping errors

### DIFF
--- a/src/auth_db/mod.rs
+++ b/src/auth_db/mod.rs
@@ -104,13 +104,13 @@ impl Display for DbError {
 
 impl From<UrlError> for DbError {
     fn from(error: UrlError) -> DbError {
-        DbError::new(format!("URL error: {}", error.description()))
+        DbError::new(format!("URL error: {:?}", error))
     }
 }
 
 impl From<RequestError> for DbError {
     fn from(error: RequestError) -> DbError {
-        DbError::new(format!("request error: {}", error.description()))
+        DbError::new(format!("request error: {:?}", error))
     }
 }
 


### PR DESCRIPTION
Extracted from #28.

External error types seem to print the most helpful information via the `Debug` trait, which can be accessed using the `{:?}` format specifier. This change just ensures we propagate that more useful information when wrapping other error types.

@mozilla/fxa-devs r?