### PR TITLE
chore(errors): don't serialize nulls in error payloads

### DIFF
--- a/src/app_errors/mod.rs
+++ b/src/app_errors/mod.rs
@@ -43,8 +43,11 @@ pub fn internal_server_error() -> Json<ApplicationError> {
 pub struct ApplicationError {
     pub status: u16,
     pub error: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub errno: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<HashMap<String, String>>,
 }
 


### PR DESCRIPTION
It was annoying me that our error payloads include explicit `nulls`, then over the weekend I spotted this fix in someone else's code. Works well, although I couldn't figure out how to write tests for it because we get the `ApplicationError` type back there, rather than the raw JSON string.

Before:

```
~/c/fxa-email-service (master) $ curl -d '{"subject":"bar","body":{"text":"baz"}}' -H 'Content-Type: application/json' http://localhost:8001/send
{"status":400,"error":"Bad Request","errno":null,"message":null,"data":null}
```

After:

```
~/c/fxa-email-service (pb/strip-nulls-from-errors) $ curl -d '{"subject":"bar","body":{"text":"baz"}}' -H 'Content-Type: application/json' http://localhost:8001/send
{"status":400,"error":"Bad Request"}
```

@mozilla/fxa-devs r?