### PR TITLE
bug: allow RFC5321 compliant email addresses

### DIFF
--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -15,7 +15,7 @@ lazy_static! {
         "^https?://[A-Za-z0-9-]+(?:\\.[A-Za-z0-9-]+)*(?::[0-9]+)?/(?:[A-Za-z0-9-]+/)*$"
     ).unwrap();
     static ref EMAIL_ADDRESS_FORMAT: Regex =
-        Regex::new("^[a-z0-9-]+@[a-z0-9-]+(?:\\.[a-z0-9-]+)+$").unwrap();
+        Regex::new("^[a-z0-9\\-!#\\$%\\&`\\*\\+/=\\?\\^{\\|}~]+@[a-z0-9-]+(?:\\.[a-z0-9-]+)+$").unwrap();
     static ref HOST_FORMAT: Regex = Regex::new("^[A-Za-z0-9-]+(?:\\.[A-Za-z0-9-]+)*$").unwrap();
     static ref PROVIDER_FORMAT: Regex = Regex::new("^(?:mock|sendgrid|ses|smtp)$").unwrap();
     static ref SENDER_NAME_FORMAT: Regex =
@@ -42,7 +42,7 @@ pub fn base_uri(value: &str) -> bool {
 }
 
 pub fn email_address(value: &str) -> bool {
-    EMAIL_ADDRESS_FORMAT.is_match(value)
+    value.len() < 254 && EMAIL_ADDRESS_FORMAT.is_match(value)
 }
 
 pub fn host(value: &str) -> bool {

--- a/src/validate/test.rs
+++ b/src/validate/test.rs
@@ -85,6 +85,9 @@ fn invalid_base_uri() {
 #[test]
 fn email_address() {
     assert!(validate::email_address("foo@example.com"));
+    assert!(validate::email_address("foo+bar@example.com"));
+    assert!(validate::email_address("foo+this#is$valid!@example.com"));
+    assert!(validate::email_address("foo+email%validation&is|a~pain!@example.com"));
     assert!(validate::email_address("accounts@firefox.com"));
     assert!(validate::email_address("verification@latest.dev.lcip.org"));
 }


### PR DESCRIPTION
email address validation is a pain, and you can use a surprising variety
of characters in an address.

(At least we're drawing the line at no quoted characters...)

Closes #44