### PR TITLE
fix(validation): relax the sendgrid API key validation regex

### DIFF
--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -21,7 +21,7 @@ lazy_static! {
     static ref PROVIDER_FORMAT: Regex = Regex::new("^(?:mock|sendgrid|ses|smtp)$").unwrap();
     static ref SENDER_NAME_FORMAT: Regex =
         Regex::new("^[A-Za-z0-9-]+(?: [A-Za-z0-9-]+)*$").unwrap();
-    static ref SENDGRID_API_KEY_FORMAT: Regex = Regex::new("^[A-Za-z0-9._]{69}$").unwrap();
+    static ref SENDGRID_API_KEY_FORMAT: Regex = Regex::new("^[A-Za-z0-9._-]+$").unwrap();
     static ref SQS_URL_FORMAT: Regex =
         Regex::new("^https://sqs\\.[a-z0-9-]+\\.amazonaws\\.com/[0-9]+/[A-Za-z0-9-]+$").unwrap();
 }

--- a/src/validate/test.rs
+++ b/src/validate/test.rs
@@ -149,23 +149,17 @@ fn invalid_sender_name() {
 #[test]
 fn sendgrid_api_key() {
     assert!(validate::sendgrid_api_key(
-        "1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz._12345"
+        "1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz._-"
     ));
 }
 
 #[test]
 fn invalid_sendgrid_api_key() {
     assert!(!validate::sendgrid_api_key(
-        "1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz._12345 "
+        "1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz._- "
     ));
     assert!(!validate::sendgrid_api_key(
-        " 1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz._12345"
-    ));
-    assert!(!validate::sendgrid_api_key(
-        "1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz._1234"
-    ));
-    assert!(!validate::sendgrid_api_key(
-        "1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz._123456"
+        " 1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz._-"
     ));
 }
 


### PR DESCRIPTION
I thought this might have been too restrictive and it was. I didn't listen to myself though, did I?

@brizental, this should let your Sendgrid API key pass validation. r?

(and @fxa-devs r?)