### PR TITLE
chore(project): remove the validator dependency

### DIFF
--- a/src/service_main.rs
+++ b/src/service_main.rs
@@ -25,9 +25,6 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde_json;
-extern crate validator;
-#[macro_use]
-extern crate validator_derive;
 
 mod app_errors;
 mod auth_db;


### PR DESCRIPTION
Fixes #41.

Since we got the sprauncy new regex in #45, I decided to quickly whip out this dependency right away. It's been annoying me for a while.

@mozilla/fxa-devs r?