### PR TITLE
feat(logging): add mozlog logging to requests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,11 +287,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "erased-serde"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "error-chain"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "backtrace 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -346,10 +373,12 @@ version = "0.1.0"
 dependencies = [
  "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "config 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "md5 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mozsvc-common 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.3.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -363,6 +392,10 @@ dependencies = [
  "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-mozlog-json 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "validator 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "validator_derive 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -392,6 +425,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crypto-mac 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hostname"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winutil 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -666,6 +708,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mozsvc-common"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "reqwest 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,6 +885,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
@@ -1283,6 +1340,47 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "slog"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "erased-serde 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "slog-async"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "slog 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "slog-mozlog-json"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "slog-term"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "chrono 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "isatty 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slog 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "smallvec"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1296,6 +1394,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "state"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "syn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "syn"
@@ -1318,8 +1426,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "take"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "take_mut"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1329,6 +1459,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "term"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1591,6 +1730,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-xid"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -1716,6 +1860,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "winutil"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "ws2_32-sys"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1782,7 +1934,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum digest 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "00a49051fef47a72c9623101b19bd71924a45cca838826caae3eaa4d00772603"
 "checksum dtoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "09c3753c3db574d215cba4ea76018483895d7bff25a31b49ba45db21c48e50ab"
 "checksum encoding_rs 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "98fd0f24d1fb71a4a6b9330c8ca04cbd4e7cc5d846b54ca74ff376bc7c9f798d"
+"checksum erased-serde 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c564e32677839f1c551664c478e079c9b128a1a2d223180bffb2ddfabeded0be"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
+"checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
+"checksum failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
@@ -1794,6 +1949,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hmac 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44f3bdb08579d99d7dc761c0e266f13b5f2ab8c8c703b9fc9ef333cd8f48f55e"
+"checksum hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"
 "checksum httparse 1.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2f407128745b78abc95c0ffbe4e5d37427fdc0d45470710cfef8c44522a2e37"
 "checksum hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)" = "368cb56b2740ebf4230520e2b90ebb0461e69034d85d1945febd9b3971426db2"
 "checksum hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)" = "34a590ca09d341e94cddf8e5af0bbccde205d5fbc2fa3c09dd67c7f85cea59d7"
@@ -1825,6 +1981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum mime_guess 2.0.0-alpha.4 (registry+https://github.com/rust-lang/crates.io-index)" = "130ea3c9c1b65dba905ab5a4d9ac59234a9585c24d135f264e187fe7336febbd"
 "checksum mio 0.6.14 (registry+https://github.com/rust-lang/crates.io-index)" = "6d771e3ef92d58a8da8df7d6976bfca9371ed1de6619d9d5a5ce5b1f29b85bfe"
 "checksum miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f2f3b1cf331de6896aabf6e9d55dca90356cc9960cca7eaaf408a355ae919"
+"checksum mozsvc-common 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "732386d576b01d7e011eedcf3d6373322ee4699bf5c46585ef416959a7f567fa"
 "checksum native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f74dbadc8b43df7864539cedb7bc91345e532fdd913cfdc23ad94f4d2d40fbc0"
 "checksum net2 0.2.32 (registry+https://github.com/rust-lang/crates.io-index)" = "9044faf1413a1057267be51b5afba8eb1090bd2231c693664aa1db716fe1eae0"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
@@ -1846,6 +2003,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "110d5ee3593dbb73f56294327fe5668bcc997897097cbc76b51e7aed3f52452f"
 "checksum proc-macro2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1b06e2f335f48d24442b35a19df506a835fb3547bc3c06ef27340da9acf5cae7"
 "checksum proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "effdb53b25cdad54f8f48843d67398f7ef2e14f12c1b4cb4effc549a6462a4d6"
+"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum quote 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9949cfe66888ffe1d53e6ec9d9f3b70714083854be20fd5e271b232a017401e8"
 "checksum quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e44651a0dc4cdd99f71c83b561e221f714912d11af1a4dff0631f923d53af035"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
@@ -1892,13 +2050,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum siphasher 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0df90a788073e8d0235a67e50441d47db7c8ad9debd91cbf43736a2a92d36537"
 "checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
 "checksum slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fdeff4cd9ecff59ec7e3744cbca73dfe5ac35c2aedb2cfba8a1c715a18912e9d"
+"checksum slog 2.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2f7bfce6405155042d42ec0e645efe43eddedd7be280063ce0623b120014e7f9"
+"checksum slog-async 2.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e544d16c6b230d84c866662fe55e31aacfca6ae71e6fc49ae9a311cb379bfc2f"
+"checksum slog-mozlog-json 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f400f1c5db96f1f52065e8931ca0c524cceb029f7537c9e6d5424488ca137ca0"
+"checksum slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5951a808c40f419922ee014c15b6ae1cd34d963538b57d8a4778b9ca3fff1e0b"
 "checksum smallvec 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c8cbcd6df1e117c2210e13ab5109635ad68a929fcbb8964dc965b76cb5ee013"
 "checksum smallvec 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "03dab98ab5ded3a8b43b2c80751194608d0b2aa0f1d46cf95d1c35e192844aa7"
 "checksum state 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7345c971d1ef21ffdbd103a75990a15eb03604fc8b8852ca8cb418ee1a099028"
+"checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum syn 0.13.11 (registry+https://github.com/rust-lang/crates.io-index)" = "14f9bf6292f3a61d2c716723fdb789a41bbe104168e6f496dc6497e531ea1b9b"
 "checksum syn 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c67da57e61ebc7b7b6fff56bb34440ca3a83db037320b0507af4c10368deda7d"
+"checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
 "checksum take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"
+"checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+"checksum term 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5e6b677dd1e8214ea1ef4297f85dbcbed8e8cdddb561040cc998ca2551c37561"
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "279ef31c19ededf577bfd12dfae728040a21f635b06a24cd670ff510edd38963"
@@ -1926,6 +2093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284b6d3db520d67fbe88fd778c21510d1b0ba4a551e5d0fbb023d33405f6de8a"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25"
+"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f392d7819dbe58833e26872f5f6f0d68b7bbbe90fc3667e98731c4a15ad9a7ae"
@@ -1944,6 +2112,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum winutil 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7daf138b6b14196e3830a588acf1e86966c694d3e8fb026fb105b8b5dca07e6e"
 "checksum ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d59cefebd0c892fa2dd6de581e937301d8552cb44489cdff035c6187cb63fa5e"
 "checksum xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3c1cb601d29fe2c2ac60a2b2e5e293994d87a1f6fa9687a31a15270f909be9c2"
 "checksum yaml-rust 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "57ab38ee1a4a266ed033496cf9af1828d8d6e6c1cfa5f643a2809effcae4d628"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,22 @@
 [package]
 name = "fxa-email-service"
 version = "0.1.0"
+[[bin]]
+name = "service"
+path = "src/service_main.rs"
+
+[[bin]]
+name = "queues"
+path = "src/queues_main.rs"
 
 [dependencies]
-chrono = { version = ">=0.4.2", features = [ "serde" ] }
 config = ">=0.8.0"
+failure = ">=0.1.1"
 futures = ">=0.1.21,<0.2"
 hex = ">=0.3.2"
 lazy_static = ">=1.0"
 md5 = ">=0.3.7"
+mozsvc-common = "0.1.0"
 regex = ">=1.0"
 reqwest = ">=0.8.5"
 rocket = ">=0.3.12"
@@ -22,13 +30,13 @@ sendgrid = ">=0.7.0"
 serde = ">=1.0"
 serde_derive = ">=1.0"
 serde_json = ">=1.0"
+slog = "2.2.3"
+slog-async = "2.3.0"
+slog-mozlog-json = "0.1.0"
+slog-term = "2.4.0"
 validator = ">=0.6.3"
 validator_derive = ">=0.6.5"
 
-[[bin]]
-name = "service"
-path = "src/service_main.rs"
-
-[[bin]]
-name = "queues"
-path = "src/queues_main.rs"
+[dependencies.chrono]
+features = ["serde"]
+version = ">=0.4.2"

--- a/config/default.json
+++ b/config/default.json
@@ -19,6 +19,7 @@
       { "period": "5 minutes", "limit": 0 }
     ]
   },
+  "jsonlogging": "false",
   "provider": "ses",
   "sender": {
     "address": "accounts@firefox.com",

--- a/config/default.json
+++ b/config/default.json
@@ -19,7 +19,7 @@
       { "period": "5 minutes", "limit": 0 }
     ]
   },
-  "jsonlogging": "false",
+  "jsonlogging": "true",
   "provider": "ses",
   "sender": {
     "address": "accounts@firefox.com",

--- a/config/dev.json
+++ b/config/dev.json
@@ -1,0 +1,3 @@
+{
+  "jsonlogging": "false"
+}

--- a/src/app_errors/mod.rs
+++ b/src/app_errors/mod.rs
@@ -3,11 +3,15 @@
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::collections::HashMap;
+use std::result;
 
+use failure::{Error};
 use rocket_contrib::Json;
 
 #[cfg(test)]
 mod test;
+
+pub type Result<T> = result::Result<T, Error>;
 
 #[error(400)]
 pub fn bad_request() -> Json<ApplicationError> {

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -1,0 +1,104 @@
+/// Logging via slog
+///
+/// Provides a RequestLogger with moz log fields per request
+ 
+use std::io;
+use std::ops::Deref;
+
+use failure::{err_msg};
+use rocket::{
+    Request, State,
+};
+use slog::{self, Drain, Record, Serializer, KV};
+use slog_async;
+use slog_mozlog_json::MozLogJson;
+use slog_term;
+
+use app_errors::Result;
+use settings::Settings;
+
+lazy_static! {
+    static ref LOGGER_NAME: String =
+        format!("{}-{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
+    static ref MSG_TYPE: String = format!("{}:log", env!("CARGO_PKG_NAME"));
+}
+
+#[derive(Clone)]
+struct MozLogFields {
+    method: &'static str,
+    path: String,
+    remote: Option<String>,
+    agent: Option<String>,
+}
+
+impl MozLogFields {
+    pub fn from_request(request: &Request) -> MozLogFields {
+        let headers = request.headers();
+        MozLogFields {
+            method: request.method().as_str(),
+            path: request.uri().to_string(),
+            agent: headers.get_one("User-Agent").map(&str::to_owned),
+            remote: headers
+                .get_one("X-Forwarded-For")
+                .map(&str::to_owned)
+                .or(request.remote().map(|addr| addr.ip().to_string())),
+        }
+    }
+}
+
+impl KV for MozLogFields {
+    fn serialize(&self, _: &Record, serializer: &mut Serializer) -> slog::Result {
+        if let Some(ref agent) = self.agent {
+            serializer.emit_str("agent", agent)?;
+        }
+        if let Some(ref remote) = self.remote {
+            serializer.emit_str("remoteAddressChain", remote)?;
+        }
+        serializer.emit_str("path", &self.path)?;
+        serializer.emit_str("method", self.method)
+    }
+}
+
+pub struct RequestLogger(slog::Logger);
+
+impl RequestLogger {
+    pub fn with_request(request: &Request) -> Result<RequestLogger> {
+        let logger = request
+            .guard::<State<RequestLogger>>()
+            .success_or(err_msg("Internal error: No managed RequestLogger"))?;
+        Ok(RequestLogger(
+            logger.new(slog_o!(MozLogFields::from_request(request))),
+        ))
+    }
+}
+
+impl Deref for RequestLogger {
+    type Target = slog::Logger;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub fn init_logging(settings: &Settings) -> Result<RequestLogger> {
+    let json_logging = match settings.jsonlogging {
+        Some(json_logging) => json_logging,
+        None => Err(err_msg("Invalid FXA_EMAIL_JSONLOGGING"))?,
+    };
+
+    let logger = if json_logging {
+        let drain = MozLogJson::new(io::stdout())
+            .logger_name(LOGGER_NAME.to_owned())
+            .msg_type(MSG_TYPE.to_owned())
+            .build()
+            .fuse();
+        let drain = slog_async::Async::new(drain).build().fuse();
+        slog::Logger::root(drain, slog_o!())
+    } else {
+        let decorator = slog_term::TermDecorator::new().build();
+        let drain = slog_term::FullFormat::new(decorator).build().fuse();
+        let drain = slog_async::Async::new(drain).build().fuse();
+        slog::Logger::root(drain, slog_o!())
+    };
+    Ok(RequestLogger(logger))
+}

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -1,6 +1,6 @@
 /// Logging via slog
 ///
-/// Provides a RequestLogger with moz log fields per request
+/// Provides a MozlogLogger with moz log fields per request
  
 use std::io;
 use std::ops::Deref;
@@ -9,13 +9,13 @@ use failure::{err_msg};
 use rocket::{
     Request, State,
 };
-use slog::{self, Drain, Record, Serializer, KV};
+use slog::{self, Drain, Record, Serializer, KV, Value, Key};
 use slog_async;
 use slog_mozlog_json::MozLogJson;
 use slog_term;
 
 use app_errors::Result;
-use settings::Settings;
+use settings::*;
 
 lazy_static! {
     static ref LOGGER_NAME: String =
@@ -24,17 +24,17 @@ lazy_static! {
 }
 
 #[derive(Clone)]
-struct MozLogFields {
+struct RequestMozlogFields {
     method: &'static str,
     path: String,
     remote: Option<String>,
     agent: Option<String>,
 }
 
-impl MozLogFields {
-    pub fn from_request(request: &Request) -> MozLogFields {
+impl RequestMozlogFields {
+    pub fn from_request(request: &Request) -> RequestMozlogFields {
         let headers = request.headers();
-        MozLogFields {
+        RequestMozlogFields {
             method: request.method().as_str(),
             path: request.uri().to_string(),
             agent: headers.get_one("User-Agent").map(&str::to_owned),
@@ -46,7 +46,7 @@ impl MozLogFields {
     }
 }
 
-impl KV for MozLogFields {
+impl KV for RequestMozlogFields {
     fn serialize(&self, _: &Record, serializer: &mut Serializer) -> slog::Result {
         if let Some(ref agent) = self.agent {
             serializer.emit_str("agent", agent)?;
@@ -55,24 +55,82 @@ impl KV for MozLogFields {
             serializer.emit_str("remoteAddressChain", remote)?;
         }
         serializer.emit_str("path", &self.path)?;
-        serializer.emit_str("method", self.method)
+        serializer.emit_str("method", self.method)?;
+
+        Ok(())
     }
 }
 
-pub struct RequestLogger(slog::Logger);
+impl Value for Settings {
+    fn serialize(&self, _: &Record, _: Key, serializer: &mut Serializer) -> slog::Result {
+        serializer.emit_str("auth_db_uri", &self.authdb.baseuri)?;
+        serializer.emit_str("provider", &self.provider)?;
 
-impl RequestLogger {
-    pub fn with_request(request: &Request) -> Result<RequestLogger> {
+        if let Some(_) = self.aws.keys {
+            serializer.emit_str("aws_keys_access", "[hidden]")?;
+        } else {
+            serializer.emit_str("aws_keys_access", "[not set]")?;
+        }
+
+        serializer.emit_str("aws_region", &self.aws.region)?;
+
+        if let Some(ref sqsurls) = self.aws.sqsurls {
+            serializer.emit_str("aws_sqs_urls_bounce", &sqsurls.bounce.to_owned())?;
+            serializer.emit_str("aws_sqs_urls_complaint", &sqsurls.complaint.to_owned())?;
+            serializer.emit_str("aws_sqs_urls_delivery", &sqsurls.delivery.to_owned())?;
+            serializer.emit_str("aws_sqs_urls_notification", &sqsurls.notification.to_owned())?;
+        } else {
+            serializer.emit_str("aws_sqs_urls", "[not set]")?;
+        }
+
+        if let Some(ref jsonlogging) = self.jsonlogging {
+            serializer.emit_str("json_logging", &format!("{}", jsonlogging))?;
+        }
+
+        if let Some(_) = self.sendgrid {
+            serializer.emit_str("sendgrid_key", "[hidden]")?;
+        } else {
+            serializer.emit_str("sendgrid_key", "[not set]")?;
+        }
+
+        serializer.emit_str("smtp_host", &self.smtp.host)?;
+        serializer.emit_str("smtp_port", &format!("{}", self.smtp.port))?;
+        
+        if let Some(ref user) = self.smtp.user {
+            serializer.emit_str("smtp_user", user)?;
+        } else {
+            serializer.emit_str("smtp_user", "[not set]")?;
+        }
+
+        if let Some(_) = self.smtp.password {
+            serializer.emit_str("smtp_password", "[hidden]")?;
+        } else {
+            serializer.emit_str("smtp_password", "[not set]")?;
+        }
+
+        serializer.emit_str("bounce_limits_enabled",  &format!("{}", &self.bouncelimits.enabled))?;
+        serializer.emit_str("bounce_limits_complaint",  &format!("{:?}", &self.bouncelimits.complaint))?;
+        serializer.emit_str("bounce_limits_hard",  &format!("{:?}", &self.bouncelimits.hard))?;
+        serializer.emit_str("bounce_limits_soft",  &format!("{:?}", &self.bouncelimits.soft))?;
+
+        Ok(())
+    }
+}
+
+pub struct MozlogLogger(slog::Logger);
+
+impl MozlogLogger {
+    pub fn with_request(request: &Request) -> Result<MozlogLogger> {
         let logger = request
-            .guard::<State<RequestLogger>>()
-            .success_or(err_msg("Internal error: No managed RequestLogger"))?;
-        Ok(RequestLogger(
-            logger.new(slog_o!(MozLogFields::from_request(request))),
+            .guard::<State<MozlogLogger>>()
+            .success_or(err_msg("Internal error: No managed MozlogLogger"))?;
+        Ok(MozlogLogger(
+            logger.new(slog_o!(RequestMozlogFields::from_request(request))),
         ))
     }
 }
 
-impl Deref for RequestLogger {
+impl Deref for MozlogLogger {
     type Target = slog::Logger;
 
     fn deref(&self) -> &Self::Target {
@@ -80,7 +138,7 @@ impl Deref for RequestLogger {
     }
 }
 
-pub fn init_logging(settings: &Settings) -> Result<RequestLogger> {
+pub fn init_logging(settings: &Settings) -> Result<MozlogLogger> {
     let json_logging = match settings.jsonlogging {
         Some(json_logging) => json_logging,
         None => Err(err_msg("Invalid FXA_EMAIL_JSONLOGGING"))?,
@@ -100,5 +158,5 @@ pub fn init_logging(settings: &Settings) -> Result<RequestLogger> {
         let drain = slog_async::Async::new(drain).build().fuse();
         slog::Logger::root(drain, slog_o!())
     };
-    Ok(RequestLogger(logger))
+    Ok(MozlogLogger(logger))
 }

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -3,10 +3,10 @@
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 
 use rocket::{
-    data::{self, FromData}, http::Status, response::Failure, Data, Outcome, Request,
+    data::{self, FromData}, response::Failure, Data, Outcome, Request
 };
 use rocket_contrib::{Json, Value};
-
+use rocket::http::Status;
 use auth_db::DbClient;
 use bounces::Bounces;
 use deserialize;

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -3,10 +3,9 @@
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 
 use rocket::{
-    data::{self, FromData}, response::Failure, Data, Outcome, Request
+    data::{self, FromData}, http::Status, response::Failure, Data, Outcome, Request
 };
 use rocket_contrib::{Json, Value};
-use rocket::http::Status;
 use auth_db::DbClient;
 use bounces::Bounces;
 use deserialize;

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -5,6 +5,7 @@
 use std::env;
 
 use config::{Config, ConfigError, Environment, File};
+use logging;
 
 use deserialize;
 
@@ -87,7 +88,7 @@ pub struct SqsUrls {
     pub notification: String,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Default, Deserialize)]
 pub struct Settings {
     pub authdb: AuthDb,
     pub aws: Aws,
@@ -132,8 +133,8 @@ impl Settings {
 
         match config.try_into::<Settings>() {
             Ok(settings) => {
-                // TODO: replace this with proper logging when we have it
-                println!("config: {:?}", settings);
+                let logger = logging::init_logging(&settings).unwrap();
+                slog_info!(logger, "{}", "Finished configuration."; "settings" => &settings);
                 Ok(settings)
             }
             Err(error) => Err(error),

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -92,11 +92,12 @@ pub struct Settings {
     pub authdb: AuthDb,
     pub aws: Aws,
     pub bouncelimits: BounceLimits,
+    pub jsonlogging: Option<bool>,
     #[serde(deserialize_with = "deserialize::provider")]
     pub provider: String,
     pub sender: Sender,
     pub sendgrid: Option<Sendgrid>,
-    pub smtp: Smtp,
+    pub smtp: Smtp
 }
 
 impl Settings {


### PR DESCRIPTION
Starts to fix #10 

I adapted the megaphone logging module for our purposes. https://github.com/mozilla-services/megaphone/blob/c7353f7e167a34aa7617cc23ac9489f395d77ff4/src/logging.rs

This is using [Fairings](https://api.rocket.rs/rocket/fairing/trait.Fairing.html) to log every time  a user makes a request. It logs when the request started and when it is done. 

There are still some more `println!`'s to replace, specially in the queues, but I thought it was best to send this in for you guys to check if I'm in the right direction.

Also, I added a new config variable `FXA_EMAIL_JSONLOGGING`, it defaults to `false`. If it's `true` it will log mozlog style. If it's `false` it will use pretty formatting.

r? @philbooth @vladikoff 