### PR TITLE
refactor(service): move bounces and providers to rocket managed state

### DIFF
--- a/src/auth_db/mod.rs
+++ b/src/auth_db/mod.rs
@@ -3,7 +3,8 @@
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::{
-    error::Error, fmt::{self, Display, Formatter},
+    error::Error,
+    fmt::{self, Display, Formatter},
 };
 
 use hex;
@@ -211,7 +212,7 @@ impl DbUrls {
     }
 }
 
-pub trait Db {
+pub trait Db: Sync {
     fn get_bounces(&self, address: &str) -> Result<Vec<BounceRecord>, DbError>;
 
     fn create_bounce(

--- a/src/bounces/mod.rs
+++ b/src/bounces/mod.rs
@@ -3,7 +3,10 @@
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::{
-    collections::HashMap, error::Error, fmt::{self, Display, Formatter}, time::SystemTime,
+    collections::HashMap,
+    error::Error,
+    fmt::{self, Display, Formatter},
+    time::SystemTime,
 };
 
 use rocket::{http::Status, response::Failure};
@@ -74,16 +77,19 @@ impl From<BounceError> for Failure {
     }
 }
 
-pub struct Bounces<'a> {
-    db: Box<&'a Db>,
-    limits: &'a BounceLimits,
+pub struct Bounces<D: Db> {
+    db: D,
+    limits: BounceLimits,
 }
 
-impl<'a> Bounces<'a> {
-    pub fn new(settings: &'a Settings, db: Box<&'a Db>) -> Bounces<'a> {
+impl<D> Bounces<D>
+where
+    D: Db,
+{
+    pub fn new(settings: &Settings, db: D) -> Bounces<D> {
         Bounces {
             db,
-            limits: &settings.bouncelimits,
+            limits: settings.bouncelimits.clone(),
         }
     }
 
@@ -115,7 +121,7 @@ impl<'a> Bounces<'a> {
     }
 }
 
-unsafe impl<'a> Sync for Bounces<'a> {}
+unsafe impl<D> Sync for Bounces<D> where D: Db {}
 
 fn is_bounce_violation(count: u8, created_at: u64, now: u64, limits: &Vec<BounceLimit>) -> bool {
     for limit in limits.iter() {

--- a/src/bounces/test.rs
+++ b/src/bounces/test.rs
@@ -31,7 +31,7 @@ fn check_no_bounces() {
     ]
   }));
     let db = DbMockNoBounce;
-    let bounces = Bounces::new(&settings, Box::new(&db));
+    let bounces = Bounces::new(&settings, db);
     if let Err(error) = bounces.check("foo@example.com") {
         assert!(false, error.description().to_string());
     }
@@ -89,7 +89,7 @@ fn check_soft_bounce() {
     "complaint": []
   }));
     let db = DbMockBounceSoft;
-    let bounces = Bounces::new(&settings, Box::new(&db));
+    let bounces = Bounces::new(&settings, db);
     match bounces.check("foo@example.com") {
         Ok(_) => assert!(false, "Bounces::check should have failed"),
         Err(error) => {
@@ -134,7 +134,7 @@ fn check_hard_bounce() {
     "complaint": []
   }));
     let db = DbMockBounceHard;
-    let bounces = Bounces::new(&settings, Box::new(&db));
+    let bounces = Bounces::new(&settings, db);
     match bounces.check("bar@example.com") {
         Ok(_) => assert!(false, "Bounces::check should have failed"),
         Err(error) => {
@@ -179,7 +179,7 @@ fn check_complaint() {
     ]
   }));
     let db = DbMockComplaint;
-    let bounces = Bounces::new(&settings, Box::new(&db));
+    let bounces = Bounces::new(&settings, db);
     match bounces.check("baz@example.com") {
         Ok(_) => assert!(false, "Bounces::check should have failed"),
         Err(error) => {
@@ -228,7 +228,7 @@ fn check_db_error() {
     ]
   }));
     let db = DbMockError;
-    let bounces = Bounces::new(&settings, Box::new(&db));
+    let bounces = Bounces::new(&settings, db);
     match bounces.check("foo@example.com") {
         Ok(_) => assert!(false, "Bounces::check should have failed"),
         Err(error) => {
@@ -266,7 +266,7 @@ fn check_no_bounces_with_nonzero_limits() {
     ]
   }));
     let db = DbMockNoBounceWithNonZeroLimits;
-    let bounces = Bounces::new(&settings, Box::new(&db));
+    let bounces = Bounces::new(&settings, db);
     if let Err(error) = bounces.check("foo@example.com") {
         assert!(false, error.description().to_string());
     }
@@ -349,7 +349,7 @@ fn check_bounce_with_multiple_limits() {
     "complaint": []
   }));
     let db = DbMockBounceWithMultipleLimits;
-    let bounces = Bounces::new(&settings, Box::new(&db));
+    let bounces = Bounces::new(&settings, db);
     match bounces.check("foo@example.com") {
         Ok(_) => assert!(false, "Bounces::check should have failed"),
         Err(error) => {

--- a/src/duration/mod.rs
+++ b/src/duration/mod.rs
@@ -3,7 +3,9 @@
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::{
-    convert::{From, TryFrom}, error::Error, fmt::{self, Display, Formatter},
+    convert::{From, TryFrom},
+    error::Error,
+    fmt::{self, Display, Formatter},
 };
 
 use regex::Regex;

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -3,7 +3,10 @@
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::{
-    boxed::Box, collections::HashMap, error::Error, fmt::{self, Display, Formatter},
+    boxed::Box,
+    collections::HashMap,
+    error::Error,
+    fmt::{self, Display, Formatter},
 };
 
 use self::{
@@ -49,14 +52,14 @@ impl Display for ProviderError {
     }
 }
 
-pub struct Providers<'s> {
-    default_provider: &'s str,
-    providers: HashMap<String, Box<Provider + 's>>,
+pub struct Providers {
+    default_provider: String,
+    providers: HashMap<String, Box<Provider>>,
 }
 
-impl<'s> Providers<'s> {
-    pub fn new(settings: &'s Settings) -> Providers {
-        let mut providers: HashMap<String, Box<Provider + 's>> = HashMap::new();
+impl Providers {
+    pub fn new(settings: &Settings) -> Providers {
+        let mut providers: HashMap<String, Box<Provider>> = HashMap::new();
 
         providers.insert(String::from("mock"), Box::new(Mock));
         providers.insert(String::from("ses"), Box::new(Ses::new(settings)));
@@ -69,7 +72,7 @@ impl<'s> Providers<'s> {
         }
 
         Providers {
-            default_provider: &settings.provider,
+            default_provider: settings.provider.clone(),
             providers,
         }
     }
@@ -83,7 +86,7 @@ impl<'s> Providers<'s> {
         body_html: Option<&str>,
         provider_id: Option<&str>,
     ) -> Result<String, ProviderError> {
-        let resolved_provider_id = provider_id.unwrap_or(self.default_provider);
+        let resolved_provider_id = provider_id.unwrap_or(&self.default_provider);
 
         self.providers
             .get(resolved_provider_id)
@@ -96,4 +99,5 @@ impl<'s> Providers<'s> {
     }
 }
 
-unsafe impl<'s> Sync for Providers<'s> {}
+unsafe impl Send for Providers {}
+unsafe impl Sync for Providers {}

--- a/src/providers/sendgrid.rs
+++ b/src/providers/sendgrid.rs
@@ -15,24 +15,21 @@ use sendgrid::{
 use super::{Provider, ProviderError};
 use settings::{Sender, Sendgrid as SendgridSettings, Settings};
 
-pub struct SendgridProvider<'s> {
+pub struct SendgridProvider {
     client: Client,
-    sender: &'s Sender,
+    sender: Sender,
 }
 
-impl<'s> SendgridProvider<'s> {
-    pub fn new(
-        sendgrid_settings: &SendgridSettings,
-        settings: &'s Settings,
-    ) -> SendgridProvider<'s> {
+impl SendgridProvider {
+    pub fn new(sendgrid_settings: &SendgridSettings, settings: &Settings) -> SendgridProvider {
         SendgridProvider {
             client: Client::new(sendgrid_settings.key.clone()),
-            sender: &settings.sender,
+            sender: settings.sender.clone(),
         }
     }
 }
 
-impl<'s> Provider for SendgridProvider<'s> {
+impl Provider for SendgridProvider {
     fn send(
         &self,
         to: &str,

--- a/src/queues/mod.rs
+++ b/src/queues/mod.rs
@@ -3,7 +3,9 @@
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::{
-    boxed::Box, error::Error, fmt::{self, Debug, Display, Formatter},
+    boxed::Box,
+    error::Error,
+    fmt::{self, Debug, Display, Formatter},
 };
 
 use futures::future::{self, Future};

--- a/src/queues/sqs/mod.rs
+++ b/src/queues/sqs/mod.rs
@@ -3,7 +3,8 @@
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::{
-    boxed::Box, fmt::{self, Debug, Formatter},
+    boxed::Box,
+    fmt::{self, Debug, Formatter},
 };
 
 use futures::future::{self, Future};

--- a/src/service_main.rs
+++ b/src/service_main.rs
@@ -36,8 +36,19 @@ mod send;
 mod settings;
 mod validate;
 
+use auth_db::DbClient;
+use bounces::Bounces;
+use providers::Providers;
+use settings::Settings;
+
 fn main() {
+    let settings = Settings::new().expect("config error");
+    let db = DbClient::new(&settings);
+    let bounces = Bounces::new(&settings, db);
+    let providers = Providers::new(&settings);
     rocket::ignite()
+        .manage(bounces)
+        .manage(providers)
         .mount("/", routes![send::handler])
         .catch(errors![
             app_errors::bad_request,

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -33,14 +33,14 @@ pub struct AwsKeys {
     pub secret: String,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 pub struct BounceLimit {
     #[serde(deserialize_with = "deserialize::duration")]
     pub period: u64,
     pub limit: u8,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 pub struct BounceLimits {
     pub enabled: bool,
     pub complaint: Vec<BounceLimit>,
@@ -48,7 +48,7 @@ pub struct BounceLimits {
     pub soft: Vec<BounceLimit>,
 }
 
-#[derive(Debug, Default, Deserialize)]
+#[derive(Clone, Debug, Default, Deserialize)]
 pub struct Sender {
     #[serde(deserialize_with = "deserialize::email_address")]
     pub address: String,

--- a/src/settings/test.rs
+++ b/src/settings/test.rs
@@ -3,7 +3,9 @@
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 
 use std::{
-    collections::{HashMap, HashSet}, env, error::Error,
+    collections::{HashMap, HashSet},
+    env,
+    error::Error,
 };
 
 use super::*;


### PR DESCRIPTION
Related to #49 and https://github.com/mozilla/fxa-email-service/pull/66#discussion_r194215830. @brizental and @vladikoff this is what I meant by making `Bounces` generic, not sure if I was very clear in my comment. It lets us keep the db stuff out of the calling module is all. Feel free to ignore if you think it's stupid!