### PR TITLE
feat(metadata): send message metadata in outgoing notifications

### DIFF
--- a/src/message_data/mod.rs
+++ b/src/message_data/mod.rs
@@ -32,6 +32,18 @@ impl MessageData {
         }
     }
 
+    pub fn consume(&self, message_id: &str) -> Result<String, MessageDataError> {
+        let key = self.generate_key(message_id)?;
+        let key_str = key.as_str();
+        self.client
+            .get(key_str)
+            .map(|metadata| {
+                self.client.del::<&str, u8>(key_str).ok();
+                metadata
+            })
+            .map_err(From::from)
+    }
+
     pub fn set(&self, message_id: &str, metadata: &str) -> Result<(), MessageDataError> {
         let key = self.generate_key(message_id)?;
         self.client.set(key.as_str(), metadata).map_err(From::from)

--- a/src/queues/notification.rs
+++ b/src/queues/notification.rs
@@ -20,6 +20,8 @@ pub struct Notification {
     pub notification_type: NotificationType,
     pub mail: Mail,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub bounce: Option<Bounce>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub complaint: Option<Complaint>,

--- a/src/queues/sqs/notification/mod.rs
+++ b/src/queues/sqs/notification/mod.rs
@@ -39,6 +39,7 @@ impl From<Notification> for GenericNotification {
         GenericNotification {
             notification_type: notification.notification_type,
             mail: From::from(notification.mail),
+            metadata: None,
             bounce: notification.bounce.map(From::from),
             complaint: notification.complaint.map(From::from),
             delivery: notification.delivery.map(From::from),


### PR DESCRIPTION
Depends on #72. Fixes #4.

Adds the ability to consume stored metadata from Redis and add it to the outgoing notification.

Again, no rush to review this, it can wait until after the All Hands.