### PR TITLE
refactor(project): push core code into a common lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,7 +368,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxa-email-service"
+name = "fxa_email_service"
 version = "0.1.0"
 dependencies = [
  "chrono 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "fxa-email-service"
+name = "fxa_email_service"
 version = "0.1.0"
 
 [dependencies]
@@ -28,11 +28,3 @@ slog = ">=2.2.3"
 slog-async = ">=2.3.0"
 slog-mozlog-json = ">=0.1.0"
 slog-term = ">=2.4.0"
-
-[[bin]]
-name = "service"
-path = "src/service_main.rs"
-
-[[bin]]
-name = "queues"
-path = "src/queues_main.rs"

--- a/src/bin/queues.rs
+++ b/src/bin/queues.rs
@@ -2,39 +2,17 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 
-#![feature(assoc_unix_epoch)]
-#![feature(try_from)]
-#![feature(type_ascription)]
-
-extern crate chrono;
-extern crate config;
 extern crate futures;
-extern crate hex;
+extern crate fxa_email_service;
 #[macro_use]
 extern crate lazy_static;
-extern crate md5;
-extern crate regex;
-extern crate reqwest;
-extern crate rusoto_core;
-extern crate rusoto_credential;
-extern crate rusoto_ses;
-extern crate rusoto_sqs;
-extern crate serde;
-#[macro_use]
-extern crate serde_derive;
-extern crate serde_json;
-
-mod auth_db;
-mod deserialize;
-mod duration;
-mod queues;
-mod settings;
-mod validate;
 
 use futures::future::{self, Future, Loop};
 
-use queues::{QueueError, QueueIds, Queues, Sqs};
-use settings::Settings;
+use fxa_email_service::{
+    queues::{QueueError, QueueIds, Queues, Sqs},
+    settings::Settings,
+};
 
 lazy_static! {
     static ref SETTINGS: Settings = Settings::new().expect("config error");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,50 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+
+#![feature(assoc_unix_epoch)]
+#![feature(plugin)]
+#![feature(try_from)]
+#![feature(type_ascription)]
+#![plugin(rocket_codegen)]
+
+extern crate chrono;
+extern crate config;
+extern crate failure;
+extern crate futures;
+extern crate hex;
+#[macro_use]
+extern crate lazy_static;
+extern crate md5;
+extern crate mozsvc_common;
+extern crate regex;
+extern crate reqwest;
+extern crate rocket;
+#[macro_use]
+extern crate rocket_contrib;
+extern crate rusoto_core;
+extern crate rusoto_credential;
+extern crate rusoto_ses;
+extern crate rusoto_sqs;
+extern crate sendgrid;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
+#[macro_use(slog_kv, slog_o)]
+extern crate slog;
+extern crate slog_async;
+extern crate slog_mozlog_json;
+extern crate slog_term;
+
+pub mod app_errors;
+pub mod auth_db;
+pub mod bounces;
+pub mod deserialize;
+pub mod duration;
+pub mod logging;
+pub mod providers;
+pub mod queues;
+pub mod send;
+pub mod settings;
+pub mod validate;


### PR DESCRIPTION
Fixes #76.

All of the code is now compiled into a common `fxa_email_service` lib, which the `service` and `queues` binaries link to. In terms of running the tests and executing the binaries, nothing has really changed. But it should mean we don't get any more dead code warnings.

No rush to review, it can wait until after the All Hands.