### PR TITLE
refactor(db): hide queues db access behind bounces interface

### DIFF
--- a/src/auth_db/mod.rs
+++ b/src/auth_db/mod.rs
@@ -4,7 +4,7 @@
 
 use std::{
     error::Error,
-    fmt::{self, Display, Formatter},
+    fmt::{self, Debug, Display, Formatter},
 };
 
 use hex;
@@ -212,7 +212,7 @@ impl DbUrls {
     }
 }
 
-pub trait Db: Sync {
+pub trait Db: Debug + Sync {
     fn get_bounces(&self, address: &str) -> Result<Vec<BounceRecord>, DbError>;
 
     fn create_bounce(


### PR DESCRIPTION
Fixes #68.

We don't want to let knowledge about the auth db leak into any unrelated application logic, because it's both temporary and in possession of capabilities that this repo has no business knowing about.

@mozilla/fxa-devs r?