### PR TITLE
fix(queues): parse notifications synthesized from sendgrid events

### DIFF
--- a/src/queues/notification.rs
+++ b/src/queues/notification.rs
@@ -34,8 +34,8 @@ pub struct Mail {
     pub timestamp: DateTime<Utc>,
     #[serde(rename = "messageId")]
     pub message_id: String,
-    pub source: String,
-    pub destination: Vec<String>,
+    pub source: Option<String>,
+    pub destination: Option<Vec<String>>,
     pub headers: Option<Vec<Header>>,
 }
 
@@ -44,8 +44,8 @@ impl Default for Mail {
         Mail {
             timestamp: Utc::now(),
             message_id: String::from(""),
-            source: String::from(""),
-            destination: Vec::new(),
+            source: None,
+            destination: None,
             headers: None,
         }
     }

--- a/src/queues/sqs/mod.rs
+++ b/src/queues/sqs/mod.rs
@@ -15,7 +15,7 @@ use rusoto_sqs::{
     DeleteMessageError, DeleteMessageRequest, Message as SqsMessage, ReceiveMessageError,
     ReceiveMessageRequest, SendMessageError, SendMessageRequest, Sqs, SqsClient,
 };
-use serde_json::{self, Error as JsonError, Value as JsonValue};
+use serde_json::{self, Error as JsonError};
 
 use self::notification::Notification as SqsNotification;
 use super::{
@@ -59,7 +59,7 @@ impl Queue {
             )));
         }
 
-        serde_json::from_value(JsonValue::String(body.clone()))
+        serde_json::from_str(&body)
             .map(|notification: SqsNotification| {
                 println!(
                     "Successfully parsed SQS message, queue=`{}`, receipt_handle=`{}`, notification_type=`{}`",

--- a/src/queues/sqs/notification/mod.rs
+++ b/src/queues/sqs/notification/mod.rs
@@ -22,7 +22,15 @@ mod test;
 // This module is a direct encoding of the SES notification format documented
 // here:
 //
-// https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notification-contents.html
+//   https://docs.aws.amazon.com/ses/latest/DeveloperGuide/notification-contents.html
+//
+// It also receives synthesized events from our Sendgrid event proxy:
+//
+//   https://github.com/mozilla/fxa-sendgrid-event-proxy
+//
+// Because we don't have all of the data to fill out an entire Notification
+// struct with the data that Sendgrid provides, many of the fields which are
+// not optional in the spec are Option-wrapped anyway.
 
 #[derive(Debug, Deserialize)]
 pub struct Notification {
@@ -115,14 +123,14 @@ pub struct Mail {
     timestamp: DateTime<Utc>,
     #[serde(rename = "messageId")]
     message_id: String,
-    source: String,
+    source: Option<String>,
     #[serde(rename = "sourceArn")]
-    source_arn: String,
+    source_arn: Option<String>,
     #[serde(rename = "sourceIp")]
-    source_ip: String,
+    source_ip: Option<String>,
     #[serde(rename = "sendingAccountId")]
-    sending_account_id: String,
-    destination: Vec<String>,
+    sending_account_id: Option<String>,
+    destination: Option<Vec<String>>,
     #[serde(rename = "headersTruncated")]
     headers_truncated: Option<String>,
     headers: Option<Vec<Header>>,
@@ -301,7 +309,7 @@ pub struct Complaint {
     #[serde(rename = "complaintFeedbackType")]
     pub complaint_feedback_type: Option<ComplaintFeedbackType>,
     #[serde(rename = "arrivalDate")]
-    pub arrival_date: DateTime<Utc>,
+    pub arrival_date: Option<DateTime<Utc>>,
 }
 
 impl From<Complaint> for GenericComplaint {
@@ -389,10 +397,10 @@ impl Serialize for ComplaintFeedbackType {
 pub struct Delivery {
     pub timestamp: DateTime<Utc>,
     #[serde(rename = "processingTimeMillis")]
-    pub processing_time_millis: u32,
+    pub processing_time_millis: Option<u32>,
     pub recipients: Vec<String>,
     #[serde(rename = "smtpResponse")]
-    pub smtp_response: String,
+    pub smtp_response: Option<String>,
     #[serde(rename = "remoteMtaIp")]
     pub remote_mta_ip: Option<String>,
     #[serde(rename = "reportingMTA")]

--- a/src/queues/sqs/notification/mod.rs
+++ b/src/queues/sqs/notification/mod.rs
@@ -168,6 +168,7 @@ pub struct Bounce {
     pub bounce_type: BounceType,
     #[serde(rename = "bounceSubType")]
     pub bounce_subtype: BounceSubtype,
+    #[serde(rename = "bouncedRecipients")]
     pub bounced_recipients: Vec<BouncedRecipient>,
     pub timestamp: DateTime<Utc>,
     #[serde(rename = "feedbackId")]


### PR DESCRIPTION
Fixes #6. Fixes #90.

There are ~~two~~ three fixes here:

* In 13ea68f, I fix a really stupid piece of code that means parsing always fails for queue notifications.

* In 12361e2, I make a bunch of fields in the `Notification` type optional, so that we can synthesize them from Sendgrid events without having to invent dummy data. It's not stuff we're actually using anyway, so it could have been optional already.

* In 8fa51ec, I fix another really stupid piece of code where it was trying to deserialize `bouncedRecipients` using the wrong name.

There are no test changes because we don't have proper test coverage for the SQS stuff yet, which probably contributed to my mistake for the first fix. But writing those tests is a bigger piece of work and landing this in the meantime means I can finally close out #6 (in combination with [mozilla/fxa-sendgrid-event-proxy](https://github.com/mozilla/fxa-sendgrid-event-proxy), which I'll request a review for separately).

@mozilla/fxa-devs r?