### PR TITLE
refactor(errors): use failure crate to handle errors

### DIFF
--- a/src/app_errors/mod.rs
+++ b/src/app_errors/mod.rs
@@ -2,65 +2,284 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::collections::HashMap;
+use std::{fmt, result};
 
+use failure::{Backtrace, Context, Fail};
+use rocket::{
+    self,
+    http::Status,
+    response::{self, Responder, Response},
+    Request,
+};
 use rocket_contrib::Json;
+use serde_json::{map::Map, ser::to_string, Value};
+
+use auth_db::BounceRecord;
+use logging::MozlogLogger;
 
 #[cfg(test)]
 mod test;
 
+pub type AppResult<T> = result::Result<T, AppError>;
+
+#[derive(Debug)]
+pub struct AppError {
+    inner: Context<AppErrorKind>,
+}
+
+impl AppError {
+    pub fn json(&self) -> Value {
+        let kind = self.kind();
+        let status = kind.http_status();
+
+        let mut fields = Map::new();
+        fields.insert(
+            String::from("code"),
+            Value::String(format!("{}", status.code)),
+        );
+        fields.insert(
+            String::from("error"),
+            Value::String(format!("{}", status.reason)),
+        );
+        let errno = kind.errno();
+        if let Some(ref errno) = errno {
+            fields.insert(String::from("errno"), Value::String(format!("{}", errno)));
+            fields.insert(String::from("message"), Value::String(format!("{}", self)));
+        };
+        let additional_fields = kind.additional_fields();
+        for (field, value) in additional_fields.iter() {
+            fields.insert(field.clone(), value.clone());
+        }
+
+        json!(fields)
+    }
+
+    pub fn kind(&self) -> &AppErrorKind {
+        self.inner.get_context()
+    }
+}
+
+impl Fail for AppError {
+    fn cause(&self) -> Option<&Fail> {
+        self.inner.cause()
+    }
+
+    fn backtrace(&self) -> Option<&Backtrace> {
+        self.inner.backtrace()
+    }
+}
+
+impl fmt::Display for AppError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.inner.fmt(f)
+    }
+}
+
+/// The specific kind of error that can occur.
+#[derive(Clone, Debug, Eq, Fail, PartialEq)]
+pub enum AppErrorKind {
+    /// 400 Bad Request
+    #[fail(display = "Bad Request")]
+    BadRequest,
+    /// 404 Not Found
+    #[fail(display = "Not Found")]
+    NotFound,
+    /// 405 Method Not Allowed
+    #[fail(display = "Method Not Allowed")]
+    MethodNotAllowed,
+    /// 422 Unprocessable Entity
+    #[fail(display = "Unprocessable Entity")]
+    UnprocessableEntity,
+    /// 429 Too Many Requests,
+    #[fail(display = "Too Many Requests")]
+    TooManyRequests,
+    /// 500 Internal Server Error
+    #[fail(display = "Internal Server Error")]
+    InternalServerError,
+    // Unexpected rocket error
+    #[fail(display = "{:?}", _0)]
+    RocketError(rocket::Error),
+
+    /// An error for invalid email params in the /send handler.
+    #[fail(display = "Error validating email params.")]
+    InvalidEmailParams,
+    /// An error for missing email params in the /send handler.
+    #[fail(display = "Missing email params.")]
+    MissingEmailParams(String),
+
+    /// An error for invalid provider names.
+    #[fail(display = "Invalid provider name: {}", _0)]
+    InvalidProvider(String),
+    /// An error for when we get an error from a provider.
+    #[fail(display = "{}", _description)]
+    ProviderError { _name: String, _description: String },
+    /// An error for when we have trouble parsing the email message.
+    #[fail(display = "{:?}", _0)]
+    EmailParsingError(String),
+
+    /// An error for when a bounce violation happens.
+    #[fail(display = "Email account sent complaint.")]
+    BounceComplaintError {
+        _address: String,
+        _bounce: Option<BounceRecord>,
+    },
+    #[fail(display = "Email account soft bounced.")]
+    BounceSoftError {
+        _address: String,
+        _bounce: Option<BounceRecord>,
+    },
+    #[fail(display = "Email account hard bounced.")]
+    BounceHardError {
+        _address: String,
+        _bounce: Option<BounceRecord>,
+    },
+
+    /// An error for when an error happens on a request to the db.
+    #[fail(display = "{:?}", _0)]
+    DbError(String),
+
+    /// An error for when we try to access functionality that is not
+    /// implemented.
+    #[fail(display = "Feature not implemented.")]
+    NotImplemented,
+}
+
+impl AppErrorKind {
+    /// Return a rocket response Status to be rendered for an error
+    pub fn http_status(&self) -> Status {
+        match self {
+            AppErrorKind::NotFound => Status::NotFound,
+            AppErrorKind::MethodNotAllowed => Status::MethodNotAllowed,
+            AppErrorKind::UnprocessableEntity => Status::UnprocessableEntity,
+            AppErrorKind::TooManyRequests => Status::TooManyRequests,
+            AppErrorKind::BounceComplaintError { .. }
+            | AppErrorKind::BounceSoftError { .. }
+            | AppErrorKind::BounceHardError { .. } => Status::TooManyRequests,
+            AppErrorKind::BadRequest | AppErrorKind::InvalidEmailParams => Status::BadRequest,
+            AppErrorKind::MissingEmailParams(_) => Status::BadRequest,
+            AppErrorKind::InternalServerError | _ => Status::InternalServerError,
+        }
+    }
+
+    pub fn errno(&self) -> Option<i32> {
+        match self {
+            AppErrorKind::RocketError(_) => Some(100),
+
+            AppErrorKind::MissingEmailParams(_) => Some(101),
+            AppErrorKind::InvalidEmailParams => Some(102),
+
+            AppErrorKind::InvalidProvider(_) => Some(103),
+            AppErrorKind::ProviderError { .. } => Some(104),
+            AppErrorKind::EmailParsingError(_) => Some(105),
+
+            AppErrorKind::BounceComplaintError { .. } => Some(106),
+            AppErrorKind::BounceSoftError { .. } => Some(107),
+            AppErrorKind::BounceHardError { .. } => Some(108),
+
+            AppErrorKind::DbError(_) => Some(109),
+
+            AppErrorKind::NotImplemented => Some(110),
+
+            AppErrorKind::BadRequest
+            | AppErrorKind::NotFound
+            | AppErrorKind::MethodNotAllowed
+            | AppErrorKind::UnprocessableEntity
+            | AppErrorKind::TooManyRequests
+            | AppErrorKind::InternalServerError => None,
+        }
+    }
+
+    pub fn additional_fields(&self) -> Map<String, Value> {
+        let mut fields = Map::new();
+        match self {
+            AppErrorKind::ProviderError {
+                ref _name,
+                ref _description,
+            } => {
+                fields.insert(String::from("name"), Value::String(format!("{}", _name)));
+            }
+
+            AppErrorKind::BounceComplaintError {
+                ref _address,
+                ref _bounce,
+            }
+            | AppErrorKind::BounceSoftError {
+                ref _address,
+                ref _bounce,
+            }
+            | AppErrorKind::BounceHardError {
+                ref _address,
+                ref _bounce,
+            } => {
+                fields.insert(
+                    String::from("address"),
+                    Value::String(format!("{}", _address)),
+                );
+                if let Some(_bounce) = _bounce {
+                    fields.insert(
+                        String::from("bounce"),
+                        Value::String(to_string(_bounce).unwrap_or(String::from("{}"))),
+                    );
+                }
+            }
+            _ => (),
+        }
+        fields
+    }
+}
+
+impl From<AppErrorKind> for AppError {
+    fn from(kind: AppErrorKind) -> AppError {
+        Context::new(kind).into()
+    }
+}
+
+impl From<Context<AppErrorKind>> for AppError {
+    fn from(inner: Context<AppErrorKind>) -> AppError {
+        AppError { inner }
+    }
+}
+
+/// Generate HTTP error responses for AppErrors
+impl<'r> Responder<'r> for AppError {
+    fn respond_to(self, request: &Request) -> response::Result<'r> {
+        let status = self.kind().http_status();
+        let json = Json(self.json());
+
+        let log = MozlogLogger::with_request(request).map_err(|_| Status::InternalServerError)?;
+        slog_error!(log, "{}", json.to_string());
+
+        let mut builder = Response::build_from(json.respond_to(request)?);
+        builder.status(status).ok()
+    }
+}
+
 #[error(400)]
-pub fn bad_request() -> Json<ApplicationError> {
-    Json(ApplicationError::new(400, "Bad Request"))
+pub fn bad_request() -> AppResult<()> {
+    Err(AppErrorKind::BadRequest)?
 }
 
 #[error(404)]
-pub fn not_found() -> Json<ApplicationError> {
-    Json(ApplicationError::new(404, "Not Found"))
+pub fn not_found() -> AppResult<()> {
+    Err(AppErrorKind::NotFound)?
 }
 
 #[error(405)]
-pub fn method_not_allowed() -> Json<ApplicationError> {
-    Json(ApplicationError::new(405, "Method Not Allowed"))
+pub fn method_not_allowed() -> AppResult<()> {
+    Err(AppErrorKind::MethodNotAllowed)?
 }
 
 #[error(422)]
-pub fn unprocessable_entity() -> Json<ApplicationError> {
-    Json(ApplicationError::new(422, "Unprocessable Entity"))
+pub fn unprocessable_entity() -> AppResult<()> {
+    Err(AppErrorKind::UnprocessableEntity)?
 }
 
 #[error(429)]
-pub fn too_many_requests() -> Json<ApplicationError> {
-    Json(ApplicationError::new(429, "Too Many Requests"))
+pub fn too_many_requests() -> AppResult<()> {
+    Err(AppErrorKind::TooManyRequests)?
 }
 
 #[error(500)]
-pub fn internal_server_error() -> Json<ApplicationError> {
-    Json(ApplicationError::new(500, "Internal Server Error"))
-}
-
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
-pub struct ApplicationError {
-    pub status: u16,
-    pub error: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub errno: Option<u8>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub message: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<HashMap<String, String>>,
-}
-
-impl ApplicationError {
-    pub fn new(status: u16, error: &str) -> ApplicationError {
-        // TODO: Set errno, message and data when rocket#596 is resolved
-        //       (https://github.com/SergioBenitez/Rocket/issues/596)
-        ApplicationError {
-            status,
-            error: error.to_string(),
-            errno: None,
-            message: None,
-            data: None,
-        }
-    }
+pub fn internal_server_error() -> AppResult<()> {
+    Err(AppErrorKind::InternalServerError)?
 }

--- a/src/app_errors/test.rs
+++ b/src/app_errors/test.rs
@@ -2,52 +2,52 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 
-use super::ApplicationError;
+use super::AppErrorKind;
 
 #[test]
 fn bad_request() {
     assert_eq!(
-        super::bad_request().into_inner(),
-        ApplicationError::new(400, "Bad Request")
+        format!("{}", super::bad_request().unwrap_err().kind()),
+        format!("{}", AppErrorKind::BadRequest)
     );
 }
 
 #[test]
 fn not_found() {
     assert_eq!(
-        super::not_found().into_inner(),
-        ApplicationError::new(404, "Not Found")
+        format!("{}", super::not_found().unwrap_err().kind()),
+        format!("{}", AppErrorKind::NotFound)
     );
 }
 
 #[test]
 fn method_not_allowed() {
     assert_eq!(
-        super::method_not_allowed().into_inner(),
-        ApplicationError::new(405, "Method Not Allowed")
+        format!("{}", super::method_not_allowed().unwrap_err().kind()),
+        format!("{}", AppErrorKind::MethodNotAllowed)
     );
 }
 
 #[test]
 fn unprocessable_entity() {
     assert_eq!(
-        super::unprocessable_entity().into_inner(),
-        ApplicationError::new(422, "Unprocessable Entity")
+        format!("{}", super::unprocessable_entity().unwrap_err().kind()),
+        format!("{}", AppErrorKind::UnprocessableEntity)
     );
 }
 
 #[test]
 fn too_many_requests() {
     assert_eq!(
-        super::too_many_requests().into_inner(),
-        ApplicationError::new(429, "Too Many Requests")
+        format!("{}", super::too_many_requests().unwrap_err().kind()),
+        format!("{}", AppErrorKind::TooManyRequests)
     );
 }
 
 #[test]
 fn internal_server_error() {
     assert_eq!(
-        super::internal_server_error().into_inner(),
-        ApplicationError::new(500, "Internal Server Error")
+        format!("{}", super::internal_server_error().unwrap_err().kind()),
+        format!("{}", AppErrorKind::InternalServerError)
     );
 }

--- a/src/auth_db/test.rs
+++ b/src/auth_db/test.rs
@@ -24,11 +24,17 @@ fn deserialize_bounce_type() {
 fn deserialize_invalid_bounce_type() {
     match serde_json::from_value::<BounceType>(From::from(4)) {
         Ok(_) => assert!(false, "serde_json::from_value should have failed"),
-        Err(error) => assert_eq!(error.description(), "JSON error"),
+        Err(error) => assert_eq!(
+            format!("{}", error),
+            "invalid value: integer `4`, expected bounce type"
+        ),
     }
     match serde_json::from_value::<BounceType>(From::from(-1)) {
         Ok(_) => assert!(false, "serde_json::from_value should have failed"),
-        Err(error) => assert_eq!(error.description(), "JSON error"),
+        Err(error) => assert_eq!(
+            format!("{}", error),
+            "invalid value: integer `-1`, expected u8"
+        ),
     }
 }
 
@@ -80,11 +86,17 @@ fn deserialize_bounce_subtype() {
 fn deserialize_invalid_bounce_subtype() {
     match serde_json::from_value::<BounceSubtype>(From::from(15)) {
         Ok(_) => assert!(false, "serde_json::from_value should have failed"),
-        Err(error) => assert_eq!(error.description(), "JSON error"),
+        Err(error) => assert_eq!(
+            format!("{}", error),
+            "invalid value: integer `15`, expected bounce subtype"
+        ),
     }
     match serde_json::from_value::<BounceSubtype>(From::from(-1)) {
         Ok(_) => assert!(false, "serde_json::from_value should have failed"),
-        Err(error) => assert_eq!(error.description(), "JSON error"),
+        Err(error) => assert_eq!(
+            format!("{}", error),
+            "invalid value: integer `-1`, expected u8"
+        ),
     }
 }
 
@@ -127,7 +139,7 @@ fn get_bounces() {
     let settings = Settings::new().expect("config error");
     let db = DbClient::new(&settings);
     if let Err(error) = db.get_bounces("foo@example.com") {
-        assert!(false, error.description().to_string());
+        assert!(false, format!("{}", error));
     }
 }
 
@@ -137,7 +149,7 @@ fn get_bounces_invalid_address() {
     let db = DbClient::new(&settings);
     match db.get_bounces("") {
         Ok(_) => assert!(false, "DbClient::get_bounces should have failed"),
-        Err(error) => assert_eq!(error.description(), "auth db response: 400 Bad Request"),
+        Err(error) => assert_eq!(format!("{}", error), "\"400 Bad Request\""),
     }
 }
 

--- a/src/bin/service.rs
+++ b/src/bin/service.rs
@@ -7,7 +7,7 @@
 
 extern crate fxa_email_service;
 extern crate rocket;
-#[macro_use(slog_b, slog_error, slog_info, slog_kv, slog_log, slog_record, slog_record_static)]
+#[macro_use(slog_b, slog_info, slog_kv, slog_log, slog_record, slog_record_static)]
 extern crate slog;
 
 use fxa_email_service::{
@@ -47,9 +47,6 @@ fn main() {
                 MozlogLogger::with_request(request).expect("MozlogLogger::with_request error");
             if response.status().code == 200 {
                 slog_info!(log, "{}", "Request finished succesfully."; 
-                    "status_code" => response.status().code, "status_msg" => response.status().reason);
-            } else {
-                slog_error!(log, "{}", "Request errored."; 
                     "status_code" => response.status().code, "status_msg" => response.status().reason);
             }
         }))

--- a/src/bounces/mod.rs
+++ b/src/bounces/mod.rs
@@ -2,83 +2,15 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::{
-    collections::HashMap,
-    error::Error,
-    fmt::{self, Display, Formatter},
-    time::SystemTime,
-};
+use std::{collections::HashMap, time::SystemTime};
 
-use rocket::{http::Status, response::Failure};
-
-use auth_db::{
-    BounceRecord, BounceSubtype as DbBounceSubtype, BounceType as DbBounceType, Db, DbError,
-};
+use app_errors::{AppErrorKind, AppResult};
+use auth_db::{BounceSubtype as DbBounceSubtype, BounceType as DbBounceType, Db};
 use queues::notification::{BounceSubtype, BounceType, ComplaintFeedbackType};
 use settings::{BounceLimit, BounceLimits, Settings};
 
 #[cfg(test)]
 mod test;
-
-#[derive(Debug)]
-pub struct BounceError {
-    pub address: String,
-    pub bounce: Option<BounceRecord>,
-    description: String,
-}
-
-impl BounceError {
-    pub fn new(address: &str, bounce: &BounceRecord) -> BounceError {
-        let description = format!(
-            "email address violated {} limit",
-            match bounce.bounce_type {
-                DbBounceType::Hard => "hard bounce",
-                DbBounceType::Soft => "soft bounce",
-                DbBounceType::Complaint => "complaint",
-            }
-        );
-
-        BounceError {
-            address: address.to_string(),
-            bounce: Some(bounce.clone()),
-            description,
-        }
-    }
-}
-
-impl Error for BounceError {
-    fn description(&self) -> &str {
-        &self.description
-    }
-}
-
-impl Display for BounceError {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(formatter, "{}", self.description)
-    }
-}
-
-impl From<DbError> for BounceError {
-    fn from(error: DbError) -> BounceError {
-        BounceError {
-            address: String::from(""),
-            bounce: None,
-            description: format!("database error: {}", error.description()),
-        }
-    }
-}
-
-impl From<BounceError> for Failure {
-    fn from(error: BounceError) -> Failure {
-        // Eventually we should be able to do something richer than this,
-        // as per https://github.com/SergioBenitez/Rocket/issues/586.
-        Failure(
-            error
-                .bounce
-                .map_or(Status::InternalServerError, |_| Status::TooManyRequests),
-        )
-    }
-}
 
 #[derive(Debug)]
 pub struct Bounces<D: Db> {
@@ -97,7 +29,7 @@ where
         }
     }
 
-    pub fn check(&self, address: &str) -> Result<(), BounceError> {
+    pub fn check(&self, address: &str) -> AppResult<()> {
         let bounces = self.db.get_bounces(address)?;
         let now = SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
@@ -115,7 +47,20 @@ where
                         DbBounceType::Complaint => &self.limits.complaint,
                     };
                     if is_bounce_violation(*count, bounce.created_at, now, limits) {
-                        return Err(BounceError::new(address, bounce));
+                        return match bounce.bounce_type {
+                            DbBounceType::Hard => Err(AppErrorKind::BounceHardError {
+                                _address: address.to_string(),
+                                _bounce: Some(bounce.clone()),
+                            }.into()),
+                            DbBounceType::Soft => Err(AppErrorKind::BounceSoftError {
+                                _address: address.to_string(),
+                                _bounce: Some(bounce.clone()),
+                            }.into()),
+                            DbBounceType::Complaint => Err(AppErrorKind::BounceComplaintError {
+                                _address: address.to_string(),
+                                _bounce: Some(bounce.clone()),
+                            }.into()),
+                        };
                     }
                 }
 
@@ -129,7 +74,7 @@ where
         address: &str,
         bounce_type: BounceType,
         bounce_subtype: BounceSubtype,
-    ) -> Result<(), BounceError> {
+    ) -> AppResult<()> {
         self.db
             .create_bounce(address, From::from(bounce_type), From::from(bounce_subtype))?;
         Ok(())
@@ -139,7 +84,7 @@ where
         &self,
         address: &str,
         complaint_type: Option<ComplaintFeedbackType>,
-    ) -> Result<(), BounceError> {
+    ) -> AppResult<()> {
         let bounce_subtype = complaint_type.map_or(DbBounceSubtype::Unmapped, |ct| From::from(ct));
         self.db
             .create_bounce(address, DbBounceType::Complaint, bounce_subtype)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate base64;
 extern crate chrono;
 extern crate config;
 extern crate emailmessage;
+#[macro_use]
 extern crate failure;
 extern crate futures;
 extern crate hex;
@@ -38,7 +39,9 @@ extern crate serde_derive;
 extern crate serde_json;
 extern crate serde_test;
 extern crate sha2;
-#[macro_use(slog_b, slog_info, slog_kv, slog_log, slog_o, slog_record, slog_record_static)]
+#[macro_use(
+    slog_b, slog_error, slog_info, slog_kv, slog_log, slog_o, slog_record, slog_record_static
+)]
 extern crate slog;
 extern crate slog_async;
 extern crate slog_mozlog_json;

--- a/src/providers/mock.rs
+++ b/src/providers/mock.rs
@@ -2,7 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 
-use super::{Headers, Provider, ProviderError};
+use super::{Headers, Provider};
+use app_errors::AppResult;
 
 pub struct MockProvider;
 
@@ -15,7 +16,7 @@ impl Provider for MockProvider {
         _subject: &str,
         _body_text: &str,
         _body_html: Option<&str>,
-    ) -> Result<String, ProviderError> {
+    ) -> AppResult<String> {
         Ok(String::from("deadbeef"))
     }
 }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -2,16 +2,12 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 
-use std::{
-    boxed::Box,
-    collections::HashMap,
-    error::Error,
-    fmt::{self, Display, Formatter},
-};
+use std::{boxed::Box, collections::HashMap};
 
 use self::{
     mock::MockProvider as Mock, sendgrid::SendgridProvider as Sendgrid, ses::SesProvider as Ses,
 };
+use app_errors::{AppErrorKind, AppResult};
 use settings::Settings;
 
 mod mock;
@@ -29,36 +25,7 @@ trait Provider {
         subject: &str,
         body_text: &str,
         body_html: Option<&str>,
-    ) -> Result<String, ProviderError>;
-}
-
-#[derive(Debug)]
-pub struct ProviderError {
-    description: String,
-}
-
-impl ProviderError {
-    pub fn new(description: String) -> ProviderError {
-        ProviderError { description }
-    }
-}
-
-impl From<String> for ProviderError {
-    fn from(error: String) -> Self {
-        ProviderError::new(error)
-    }
-}
-
-impl Error for ProviderError {
-    fn description(&self) -> &str {
-        &self.description
-    }
-}
-
-impl Display for ProviderError {
-    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(formatter, "{}", self.description)
-    }
+    ) -> AppResult<String>;
 }
 
 pub struct Providers {
@@ -95,14 +62,12 @@ impl Providers {
         body_text: &str,
         body_html: Option<&str>,
         provider_id: Option<&str>,
-    ) -> Result<String, ProviderError> {
+    ) -> AppResult<String> {
         let resolved_provider_id = provider_id.unwrap_or(&self.default_provider);
 
         self.providers
             .get(resolved_provider_id)
-            .ok_or_else(|| {
-                ProviderError::new(format!("Invalid provider `{}`", resolved_provider_id))
-            })
+            .ok_or_else(|| AppErrorKind::InvalidProvider(String::from(resolved_provider_id)).into())
             .and_then(|provider| provider.send(to, cc, headers, subject, body_text, body_html))
             .map(|message_id| format!("{}:{}", resolved_provider_id, message_id))
     }

--- a/src/queues/mod.rs
+++ b/src/queues/mod.rs
@@ -12,8 +12,9 @@ use futures::future::{self, Future};
 
 use self::notification::{Notification, NotificationType};
 pub use self::sqs::Queue as Sqs;
+use app_errors::AppError;
 use auth_db::DbClient;
-use bounces::{BounceError, Bounces};
+use bounces::Bounces;
 use message_data::MessageData;
 use settings::Settings;
 
@@ -203,8 +204,8 @@ impl Display for QueueError {
     }
 }
 
-impl From<BounceError> for QueueError {
-    fn from(error: BounceError) -> QueueError {
+impl From<AppError> for QueueError {
+    fn from(error: AppError) -> QueueError {
         QueueError::new(format!("bounce error: {:?}", error))
     }
 }


### PR DESCRIPTION
Connects to #48 

I had to change basically everything since my last PR (#85) about this, so I thought it would be best to just create a new PR.

To  get the failure errors working I needed to get at least `providers`, `bounces` and `db` to also work with the failure errors, not just the Rocket and HTTP errors. That's what I'm doing in this PR. Since this is kind of a big change, I thought it would be best to send this in before adapting the tests to the new error type, so, right now, many tests are commented.

Let me know what you guys think. If you think this is a good change I still would need to adapt all tests and also there are some error types specially for the queues bin that need to be changed as well.

I personally think this is a good change. It is abstracting all the errors to one single place in the code. While working on this refactoring, I saw a bunch of repeated code for error handling. This ends that, which means it will be easier to maintain and create new error types with this way of doing things. Also, we are now getting much more information about each error, not just the HTTP status and message and it's very easy to customize this even further.

Anyways, this still has a bunch of work to be ready to merge :)

r? @vladikoff @philbooth @pjenvey