### PR TITLE
feat(logging): add null logger for testing environment

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -20,7 +20,7 @@
     ]
   },
   "message_id_hmac_key": "YOU MUST CHANGE ME",
-  "mozlog": "true",
+  "logging": "mozlog",
   "provider": "ses",
   "redis": {
     "host": "127.0.0.1",

--- a/config/dev.json
+++ b/config/dev.json
@@ -1,3 +1,3 @@
 {
-  "mozlog": "false"
+  "logging": "pretty"
 }

--- a/config/test.json
+++ b/config/test.json
@@ -1,0 +1,3 @@
+{
+    "logging": "null"
+}

--- a/scripts/test_standalone.sh
+++ b/scripts/test_standalone.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
 
 export RUST_BACKTRACE=1
+
+if [ -z "$NODE_ENV" ]; then
+  export NODE_ENV=test
+fi
+
 cargo test -- --test-threads=1

--- a/scripts/test_with_authdb.sh
+++ b/scripts/test_with_authdb.sh
@@ -17,5 +17,9 @@ fi
 
 sleep 2
 
+if [ -z "$NODE_ENV" ]; then
+  export NODE_ENV=test
+fi
+
 export RUST_BACKTRACE=1
 cargo test -- --test-threads=1

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -94,7 +94,7 @@ pub struct Settings {
     pub aws: Aws,
     pub bouncelimits: BounceLimits,
     pub message_id_hmac_key: String,
-    pub mozlog: bool,
+    pub logging: String,
     #[serde(deserialize_with = "deserialize::provider")]
     pub provider: String,
     pub redis: Redis,


### PR DESCRIPTION
Fixes #82 

When we are in a testing environment (which means when `NODE_ENV=test`) the logger won't show anything. 

So now, instead of having `mozlog:true | false` in the config, we have `logging: null | pretty | mozlog`.

r? @vladikoff 