### PR TITLE
chore(settings): prepare prod and stage configs for deployment

### DIFF
--- a/Rocket.toml
+++ b/Rocket.toml
@@ -1,2 +1,11 @@
 [development]
+address = "127.0.0.1"
+port = 8001
+
+[staging]
+address = "127.0.0.1"
+port = 8001
+
+[production]
+address = "127.0.0.1"
 port = 8001


### PR DESCRIPTION
Fixes #100 
Fixes #24 

As mentioned in #24 we still need to see about `ROCKET_WORKERS`.

Also, in production, rocket sends a warning about not having set a secret_key, but I decided to leave it without anything for now. Anyways that would be something that probably we wouldn't "hard code" here.

r? @vladikoff @philbooth 