### PR TITLE
fix(settings): get message data hmac key setting to work with env variables

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -19,7 +19,7 @@
       { "period": "5 minutes", "limit": 0 }
     ]
   },
-  "message_id_hmac_key": "YOU MUST CHANGE ME",
+  "hmackey": "YOU MUST CHANGE ME",
   "logging": "mozlog",
   "provider": "ses",
   "redis": {

--- a/src/message_data/mod.rs
+++ b/src/message_data/mod.rs
@@ -28,7 +28,7 @@ impl MessageData {
             client: RedisClient::open(
                 format!("redis://{}:{}/", settings.redis.host, settings.redis.port).as_str(),
             ).expect("redis connection error"),
-            hmac_key: settings.message_id_hmac_key.clone(),
+            hmac_key: settings.hmackey.clone(),
         }
     }
 

--- a/src/message_data/test.rs
+++ b/src/message_data/test.rs
@@ -63,7 +63,7 @@ impl TestFixture {
     pub fn setup(test: &str) -> TestFixture {
         let settings = Settings::new().expect("config error");
         let unhashed_key = format!("fxa-email-service.test.message-data.{}.{}", test, now());
-        let mut hmac = Hmac::<Sha256>::new_varkey(settings.message_id_hmac_key.as_bytes()).unwrap();
+        let mut hmac = Hmac::<Sha256>::new_varkey(settings.hmackey.as_bytes()).unwrap();
         hmac.input(unhashed_key.as_bytes());
         let internal_key = format!("msg:{:x}", hmac.result().code());
         TestFixture {

--- a/src/settings/test.rs
+++ b/src/settings/test.rs
@@ -65,6 +65,7 @@ fn env_vars_take_precedence() {
         "FXA_EMAIL_AWS_SQSURLS_DELIVERY",
         "FXA_EMAIL_AWS_SQSURLS_NOTIFICATION",
         "FXA_EMAIL_BOUNCELIMITS_ENABLED",
+        "FXA_EMAIL_MESSAGEDATA_HMACKEY",
         "FXA_EMAIL_PROVIDER",
         "FXA_EMAIL_REDIS_HOST",
         "FXA_EMAIL_REDIS_PORT",
@@ -114,6 +115,7 @@ fn env_vars_take_precedence() {
                 }
             };
             let bounce_limits_enabled = !settings.bouncelimits.enabled;
+            let hmac_key = String::from("something else");
             let provider = if settings.provider == "ses" {
                 "sendgrid"
             } else {
@@ -142,6 +144,7 @@ fn env_vars_take_precedence() {
                 "FXA_EMAIL_BOUNCELIMITS_ENABLED",
                 &bounce_limits_enabled.to_string(),
             );
+            env::set_var("FXA_EMAIL_HMACKEY", &hmac_key.to_string());
             env::set_var("FXA_EMAIL_PROVIDER", &provider);
             env::set_var("FXA_EMAIL_REDIS_HOST", &redis_host);
             env::set_var("FXA_EMAIL_REDIS_PORT", &redis_port.to_string());
@@ -154,6 +157,7 @@ fn env_vars_take_precedence() {
                     assert_eq!(env_settings.authdb.baseuri, auth_db_base_uri);
                     assert_eq!(env_settings.aws.region, aws_region);
                     assert_eq!(env_settings.bouncelimits.enabled, bounce_limits_enabled);
+                    assert_eq!(env_settings.hmackey, hmac_key);
                     assert_eq!(env_settings.provider, provider);
                     assert_eq!(env_settings.redis.host, redis_host);
                     assert_eq!(env_settings.redis.port, redis_port);


### PR DESCRIPTION
Fixes #109 

Because we had underscores in the name of this setting, it wasn't getting overwritten by an `FXA_EMAIL_` environment variable. At first I thought this was a bug with `config-rs` but it actually looks like a design choice, because they use underscores to signal nesting. For example:

```
  "authdb": {
    "baseuri": "http://127.0.0.1:8000/"
  }
```

Will get overwritten by the environment variable `FXA_EMAIL_AUTHDB_BASEURI`.

Anyways, to fix this I changed the `message_id_hmac_key` setting to not have any underscores. Since that was too long for just removing the underscores, I did a little nesting for the resulting environment variable to look nicer. Now, to overwrite the hmac key we can just use `FXA_EMAIL_MESSAGEDATA_HMACKEY`.

I also added that to our settings tests, so that we can make sure it works.

Finally, I remember @philbooth commenting that this is sensitive data that we should probably hide when logging. Should I add a deserializer macro to hide this?

r? @philbooth @vladikoff 

---

[UPDATE]

Looking at `config-rs` source code made me wonder if this really isn't a bug... I filed an issue there (https://github.com/mehcode/config-rs/issues/73) and will try to investigate it.

