### PR TITLE
fix(docs): better docs for the settings module

### DIFF
--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -173,22 +173,23 @@ pub struct Sendgrid {
 }
 
 /// URLs for SQS queues.
+///
 /// Note that these are separate queues right now
 /// for consistency with the auth server.
 /// Long term,
 /// there is nothing preventing us
 /// from handling all incoming notification types
 /// with a single queue.
+///
+/// Queue URLs are specified
+/// for consistency with the auth server.
+/// However, we could also store queue names instead
+/// and then fetch the URL with rusoto_sqs::GetQueueUrl.
+/// Then we might be allowed to include
+/// the production queue names in default config?
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct SqsUrls {
     /// The incoming bounce queue URL.
-    ///
-    /// Queue URLs are specified here
-    /// for consistency with the auth server.
-    /// However, we could also store queue names instead
-    /// and then fetch the URL with rusoto_sqs::GetQueueUrl.
-    /// Then we might be allowed to include
-    /// the production queue names in default config?
     pub bounce: SqsUrl,
 
     /// The incoming complaint queue URL.

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -22,7 +22,8 @@ use validate;
 mod test;
 
 macro_rules! deserialize_and_validate {
-    ($(($type:ident, $validator:ident, $expected:expr)),+) => ($(
+    ($(#[$docs:meta] ($type:ident, $validator:ident, $expected:expr)),+) => ($(
+        #[$docs]
         #[derive(Clone, Debug, Default, Serialize, PartialEq)]
         pub struct $type(pub String);
 
@@ -50,16 +51,26 @@ macro_rules! deserialize_and_validate {
 }
 
 deserialize_and_validate! {
-    (AwsAccess, aws_access, "aws access"),
-    (AwsRegion, aws_region, "aws region"),
-    (AwsSecret, aws_secret, "aws secret"),
-    (BaseUri, base_uri, "base uri"),
-    (Host, host, "host name or ip address"),
-    (Logging, logging, "'mozlog', 'pretty' ou 'null'"),
+    /// AWS access key type.
+    (AwsAccess, aws_access, "AWS access key"),
+    /// AWS region type.
+    (AwsRegion, aws_region, "AWS region"),
+    /// AWS secret key type.
+    (AwsSecret, aws_secret, "AWS secret key"),
+    /// Base URI type.
+    (BaseUri, base_uri, "base URI"),
+    /// Host name or IP address type.
+    (Host, host, "host name or IP address"),
+    /// Logging format type.
+    (Logging, logging, "'mozlog', 'pretty' or 'null'"),
+    /// Email provider type.
     (Provider, provider, "'ses' or 'sendgrid'"),
+    /// Sender name type.
     (SenderName, sender_name, "sender name"),
-    (SendgridApiKey, sendgrid_api_key, "sendgrid api key"),
-    (SqsUrl, sqs_url, "sqs queue url")
+    /// Sendgrid API key type.
+    (SendgridApiKey, sendgrid_api_key, "Sendgrid API key"),
+    /// AWS SQS queue URL type.
+    (SqsUrl, sqs_url, "SQS queue URL")
 }
 
 /// Settings related to `fxa-auth-db-mysql`,


### PR DESCRIPTION
A couple of small documentation fixes, not associated with any issue:

* Add a docstring to the `derive_and_validate` macro expansion. All the other types in `settings` have a doc comment and the generated docs looked incomplete without it for these too.

* Fix up the docs for `SqsUrls`, introducing a newline to keep the outer summary short and moving another note up from the wrong place where it was associated with `SqsUrls::bounce`.

With these changes, the `settings` docs look like this:

<img width="1057" alt="Screen shot of the settings documentation" src="https://user-images.githubusercontent.com/64367/42377798-c70dd7bc-811c-11e8-9ddb-1d89b1fd1682.png" />

@brizental, @mozilla/fxa-devs r?