### PR TITLE
feat(logging): turn off rocket logs for production

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,11 +169,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "cookie"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.11.0-dev"
+source = "git+https://github.com/alexcrichton/cookie-rs?rev=0365a18#0365a18e4518e498ac6a508dab6b006add7f162e"
 dependencies = [
- "base64 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ring 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ring 0.13.0-alpha5 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -205,34 +205,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-deque"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam-epoch 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -246,14 +223,6 @@ dependencies = [
  "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "memoffset 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -502,9 +471,9 @@ dependencies = [
  "redis 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket_codegen 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket_contrib 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)",
+ "rocket_codegen 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)",
+ "rocket_contrib 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)",
  "rusoto_core 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_credential 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_ses 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -520,11 +489,6 @@ dependencies = [
  "slog-mozlog-json 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "gcc"
-version = "0.3.54"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "generic-array"
@@ -638,6 +602,11 @@ dependencies = [
  "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "indexmap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "iovec"
@@ -974,20 +943,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "ordermap"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "pear"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.1.0"
+source = "git+http://github.com/SergioBenitez/Pear?rev=54667ae#54667aefef084f2411e86392402a955770f1e7aa"
+dependencies = [
+ "pear_codegen 0.1.0 (git+http://github.com/SergioBenitez/Pear?rev=54667ae)",
+]
 
 [[package]]
 name = "pear_codegen"
-version = "0.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.1.0"
+source = "git+http://github.com/SergioBenitez/Pear?rev=54667ae#54667aefef084f2411e86392402a955770f1e7aa"
 dependencies = [
+ "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "yansi 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1099,26 +1069,6 @@ dependencies = [
 name = "rand_core"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "rayon"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "redis"
@@ -1233,60 +1183,79 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.11.0"
+version = "0.13.0-alpha5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "rayon 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rocket"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.4.0-dev"
+source = "git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643#18a91c938eb534a410a76137fbf114333ab38643"
 dependencies = [
  "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "cookie 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "isatty 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "pear 0.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "pear_codegen 0.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "smallvec 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pear 0.1.0 (git+http://github.com/SergioBenitez/Pear?rev=54667ae)",
+ "rocket_codegen_next 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)",
+ "rocket_http 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)",
  "state 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "yansi 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rocket_codegen"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.4.0-dev"
+source = "git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643#18a91c938eb534a410a76137fbf114333ab38643"
 dependencies = [
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_http 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)",
  "version_check 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "yansi 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "rocket_contrib"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+name = "rocket_codegen_next"
+version = "0.4.0-dev"
+source = "git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643#18a91c938eb534a410a76137fbf114333ab38643"
 dependencies = [
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rocket_contrib"
+version = "0.4.0-dev"
+source = "git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643#18a91c938eb534a410a76137fbf114333ab38643"
+dependencies = [
+ "log 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)",
  "serde 1.0.66 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rocket_http"
+version = "0.4.0-dev"
+source = "git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643#18a91c938eb534a410a76137fbf114333ab38643"
+dependencies = [
+ "cookie 0.11.0-dev (git+https://github.com/alexcrichton/cookie-rs?rev=0365a18)",
+ "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pear 0.1.0 (git+http://github.com/SergioBenitez/Pear?rev=54667ae)",
+ "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1957,7 +1926,7 @@ dependencies = [
 
 [[package]]
 name = "untrusted"
-version = "0.5.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2105,15 +2074,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum config 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e595d1735d8ab6b04906bbdcfc671cce2a5e609b6f8e92865e67331cc2f41ba4"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
-"checksum cookie 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "477eb650753e319be2ae77ec368a58c638f9f0c4d941c39bad95e950fb1d1d0d"
+"checksum cookie 0.11.0-dev (git+https://github.com/alexcrichton/cookie-rs?rev=0365a18)" = "<none>"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
-"checksum crossbeam-deque 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f739f8c5363aca78cfb059edf753d8f0d36908c348f3d8d1503f03d8b75d9cf3"
 "checksum crossbeam-deque 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fe8153ef04a7594ded05b427ffad46ddeaf22e63fd48d42b3e1e3bb4db07cae7"
-"checksum crossbeam-epoch 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "927121f5407de9956180ff5e936fe3cf4324279280001cd56b669d28ee7e9150"
 "checksum crossbeam-epoch 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2af0e75710d6181e234c8ecc79f14a97907850a541b13b0be1dd10992f2e4620"
-"checksum crossbeam-utils 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "2760899e32a1d58d5abb31129f8fae5de75220bc2176e77ff7c627ae45c918d9"
 "checksum crossbeam-utils 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d636a8b3bcc1b409d7ffd3facef8f21dcb4009626adbd0c5e6c4305c07253c7b"
 "checksum crypto-mac 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0999b4ff4d3446d4ddb19a63e9e00c1876e75cd7000d20e57a693b4b3f08d958"
 "checksum crypto-mac 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7afa06d05a046c7a47c3a849907ec303504608c927f4e85f7bfff22b7180d971"
@@ -2142,7 +2108,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)" = "1a70b146671de62ec8c8ed572219ca5d594d9b06c0b364d5e67b722fc559b48c"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
-"checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hmac 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44f3bdb08579d99d7dc761c0e266f13b5f2ab8c8c703b9fc9ef333cd8f48f55e"
@@ -2153,6 +2118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)" = "34a590ca09d341e94cddf8e5af0bbccde205d5fbc2fa3c09dd67c7f85cea59d7"
 "checksum hyper-tls 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a5aa51f6ae9842239b0fac14af5f22123b8432b4cc774a44ff059fcba0f675ca"
 "checksum idna 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "014b298351066f1512874135335d62a789ffe78a9974f94b43ed5621951eaf7d"
+"checksum indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08173ba1e906efb6538785a8844dd496f5d34f0a2d88038e95195172fc667220"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum isatty 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "6c324313540cd4d7ba008d43dc6606a32a5579f13cc17b2804c13096f0a5c522"
 "checksum itoa 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c069bbec61e1ca5a596166e55dfe4773ff745c3d16b700013bcaff9a6df2c682"
@@ -2192,9 +2158,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "a3605c298474a3aa69de92d21139fb5e2a81688d308262359d85cdd0d12a7985"
 "checksum openssl-sys 0.9.33 (registry+https://github.com/rust-lang/crates.io-index)" = "d8abc04833dcedef24221a91852931df2f63e3369ae003134e70aff3645775cc"
-"checksum ordermap 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)" = "b81cf3b8cb96aa0e73bbedfcdc9708d09fec2854ba8d474be4e6f666d7379e8b"
-"checksum pear 0.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "e868f6a0ac6ea21cbc8bcead234c875209523cc50dddc12b082c09c06a84f85a"
-"checksum pear_codegen 0.0.18 (registry+https://github.com/rust-lang/crates.io-index)" = "758ab26a919053f465d887a454f93c39735c615bc36b5598405f557cc033ae88"
+"checksum pear 0.1.0 (git+http://github.com/SergioBenitez/Pear?rev=54667ae)" = "<none>"
+"checksum pear_codegen 0.1.0 (git+http://github.com/SergioBenitez/Pear?rev=54667ae)" = "<none>"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum phf 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)" = "7d37a244c75a9748e049225155f56dbcb98fe71b192fd25fd23cb914b5ad62f2"
 "checksum phf_codegen 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)" = "4e4048fe7dd7a06b8127ecd6d3803149126e9b33c7558879846da3a63f734f2b"
@@ -2209,8 +2174,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "eba5f8cb59cc50ed56be8880a5c7b496bfd9bd26394e176bc67884094145c2c5"
 "checksum rand 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d0d9f869af32e387d9e0f2bdb64326b8ac84c81d5e55459d0bc7526b0fdb3671"
 "checksum rand_core 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "edecf0f94da5551fc9b492093e30b041a891657db7940ee221f9d2f66e82eef2"
-"checksum rayon 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a77c51c07654ddd93f6cb543c7a849863b03abc7e82591afda6dc8ad4ac3ac4a"
-"checksum rayon-core 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9d24ad214285a7729b174ed6d3bcfcb80177807f959d95fafd5bfc5c4f201ac8"
 "checksum redis 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02a92e223490cc63d9230c4cdf132a48ce154ab1e063558e3841e219c2ea3f91"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
@@ -2222,10 +2185,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum relay 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1576e382688d7e9deecea24417e350d3062d97e32e45d70b1cde65994ff1489a"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum reqwest 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2abe46f8e00792693a2488e296c593d1f4ea39bb1178cfce081d6793657575e4"
-"checksum ring 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1f2a6dc7fc06a05e6de183c5b97058582e9da2de0c136eafe49609769c507724"
-"checksum rocket 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "798935129effaaf50a4647dbd96bf48cedb3d06c16ab645405d9f02fb90a29d0"
-"checksum rocket_codegen 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "dca5401b057885267f9b0d81138b7f0b926549261b5cc429ee5535166c47b8e8"
-"checksum rocket_contrib 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "f04b11a285fb5b0ce426241468aa0494f0b5ca981bda5198facd0106d8edd731"
+"checksum ring 0.13.0-alpha5 (registry+https://github.com/rust-lang/crates.io-index)" = "3845516753f91b4511f9b17c917ea6fa4bc5a7853a9947b0f66731aff51cdef5"
+"checksum rocket 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)" = "<none>"
+"checksum rocket_codegen 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)" = "<none>"
+"checksum rocket_codegen_next 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)" = "<none>"
+"checksum rocket_contrib 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)" = "<none>"
+"checksum rocket_http 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)" = "<none>"
 "checksum rusoto_core 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12daaa6d62d64f6447bf0299ce775f4e05f8e75e5418e817da094b9de04ad22d"
 "checksum rusoto_credential 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "53199d09fd1b7d4f5ac50f4d23106577624238ea77cae2b44eb1d1fc4cd956a4"
 "checksum rusoto_ses 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "88d4645c94b099369602db7d814b1741f991b3d6821d8076b2ac67824b8cc130"
@@ -2301,7 +2266,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-"checksum untrusted 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f392d7819dbe58833e26872f5f6f0d68b7bbbe90fc3667e98731c4a15ad9a7ae"
+"checksum untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "55cd1f4b4e96b46aeb8d4855db4a7a9bd96eeeb5c6a1ab54593328761642ce2f"
 "checksum url 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f808aadd8cfec6ef90e4a14eb46f24511824d1ac596b9682703c87056c8678b7"
 "checksum utf8-ranges 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a1ca13c08c41c9c3e04224ed9ff80461d97e121589ff27c753a16cb10830ae0f"
 "checksum utf8-ranges 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "662fab6525a98beff2921d7f61a39e7d59e0b425ebc7d0d9e66d316e55124122"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,9 +29,10 @@ rand = ">=0.5.1"
 redis = ">=0.8.0"
 regex = ">=1.0"
 reqwest = ">=0.8.5"
-rocket = ">=0.3.14"
-rocket_codegen = ">=0.3.14"
-rocket_contrib = ">=0.3.14"
+# Remove once a new version of rocket containing this commit is released.
+rocket = { git = "https://github.com/SergioBenitez/Rocket", rev="18a91c938eb534a410a76137fbf114333ab38643" }
+rocket_codegen = { git = "https://github.com/SergioBenitez/Rocket", rev="18a91c938eb534a410a76137fbf114333ab38643" }
+rocket_contrib = { git = "https://github.com/SergioBenitez/Rocket", rev="18a91c938eb534a410a76137fbf114333ab38643" }
 rusoto_core = ">=0.32.0"
 rusoto_credential = ">=0.11.0"
 rusoto_ses = ">=0.32.0"

--- a/Rocket.toml
+++ b/Rocket.toml
@@ -7,5 +7,6 @@ address = "127.0.0.1"
 port = 8001
 
 [production]
+log = "off"
 address = "127.0.0.1"
 port = 8001

--- a/src/app_errors/mod.rs
+++ b/src/app_errors/mod.rs
@@ -13,7 +13,7 @@ use rocket::{
     response::{self, Responder, Response},
     Request,
 };
-use rocket_contrib::Json;
+use rocket_contrib::{Json, JsonValue};
 use serde_json::{map::Map, ser::to_string, Value};
 
 use auth_db::BounceRecord;
@@ -38,7 +38,7 @@ pub struct AppError {
 }
 
 impl AppError {
-    pub fn json(&self) -> Value {
+    pub fn json(&self) -> JsonValue {
         let kind = self.kind();
         let status = kind.http_status();
 
@@ -264,32 +264,32 @@ impl<'r> Responder<'r> for AppError {
     }
 }
 
-#[error(400)]
+#[catch(400)]
 pub fn bad_request() -> AppResult<()> {
     Err(AppErrorKind::BadRequest)?
 }
 
-#[error(404)]
+#[catch(404)]
 pub fn not_found() -> AppResult<()> {
     Err(AppErrorKind::NotFound)?
 }
 
-#[error(405)]
+#[catch(405)]
 pub fn method_not_allowed() -> AppResult<()> {
     Err(AppErrorKind::MethodNotAllowed)?
 }
 
-#[error(422)]
+#[catch(422)]
 pub fn unprocessable_entity() -> AppResult<()> {
     Err(AppErrorKind::UnprocessableEntity)?
 }
 
-#[error(429)]
+#[catch(429)]
 pub fn too_many_requests() -> AppResult<()> {
     Err(AppErrorKind::TooManyRequests)?
 }
 
-#[error(500)]
+#[catch(500)]
 pub fn internal_server_error() -> AppResult<()> {
     Err(AppErrorKind::InternalServerError)?
 }

--- a/src/bin/service.rs
+++ b/src/bin/service.rs
@@ -45,7 +45,7 @@ fn main() {
         .manage(message_data)
         .manage(providers)
         .mount("/", routes![send::handler])
-        .catch(errors![
+        .catch(catchers![
             app_errors::bad_request,
             app_errors::not_found,
             app_errors::method_not_allowed,

--- a/src/bounces/test.rs
+++ b/src/bounces/test.rs
@@ -22,18 +22,21 @@ const MONTH: u64 = DAY * 30;
 
 #[test]
 fn check_no_bounces() {
-    let settings = create_settings(json!({
-    "enabled": true,
-    "soft": [
-      { "period": "day", "limit": 0 }
-    ],
-    "hard": [
-      { "period": "week", "limit": 0 }
-    ],
-    "complaint": [
-      { "period": "month", "limit": 0 }
-    ]
-  }));
+    let bounce_settings: Json = serde_json::from_str(
+        r#"{
+        "enabled": true,
+        "soft": [
+        { "period": "day", "limit": 0 }
+        ],
+        "hard": [
+        { "period": "week", "limit": 0 }
+        ],
+        "complaint": [
+        { "period": "month", "limit": 0 }
+        ]
+        }"#,
+    ).expect("Unexpected json parsing error.");
+    let settings = create_settings(bounce_settings);
     let db = DbMockNoBounce;
     let bounces = Bounces::new(&settings, db);
     if let Err(error) = bounces.check("foo@example.com") {
@@ -85,14 +88,17 @@ fn now_as_milliseconds() -> u64 {
 
 #[test]
 fn check_soft_bounce() {
-    let settings = create_settings(json!({
-    "enabled": true,
-    "soft": [
-      { "period": "day", "limit": 0 }
-    ],
-    "hard": [],
-    "complaint": []
-  }));
+    let bounce_settings: Json = serde_json::from_str(
+        r#"{
+        "enabled": true,
+        "soft": [
+        { "period": "day", "limit": 0 }
+        ],
+        "hard": [],
+        "complaint": []
+        }"#,
+    ).expect("Unexpected json parsing error.");
+    let settings = create_settings(bounce_settings);
     let db = DbMockBounceSoft;
     let bounces = Bounces::new(&settings, db);
     match bounces.check("foo@example.com") {
@@ -135,14 +141,17 @@ impl Db for DbMockBounceSoft {
 
 #[test]
 fn check_hard_bounce() {
-    let settings = create_settings(json!({
-    "enabled": true,
-    "soft": [],
-    "hard": [
-      { "period": "week", "limit": 0 }
-    ],
-    "complaint": []
-  }));
+    let bounce_settings: Json = serde_json::from_str(
+        r#"{
+        "enabled": true,
+        "soft": [],
+        "hard": [
+        { "period": "week", "limit": 0 }
+        ],
+        "complaint": []
+        }"#,
+    ).expect("Unexpected json parsing error.");
+    let settings = create_settings(bounce_settings);
     let db = DbMockBounceHard;
     let bounces = Bounces::new(&settings, db);
     match bounces.check("bar@example.com") {
@@ -185,14 +194,17 @@ impl Db for DbMockBounceHard {
 
 #[test]
 fn check_complaint() {
-    let settings = create_settings(json!({
-    "enabled": true,
-    "soft": [],
-    "hard": [],
-    "complaint": [
-      { "period": "month", "limit": 0 }
-    ]
-  }));
+    let bounce_settings: Json = serde_json::from_str(
+        r#"{
+        "enabled": true,
+        "soft": [],
+        "hard": [],
+        "complaint": [
+        { "period": "month", "limit": 0 }
+        ]
+        }"#,
+    ).expect("Unexpected json parsing error.");
+    let settings = create_settings(bounce_settings);
     let db = DbMockComplaint;
     let bounces = Bounces::new(&settings, db);
     match bounces.check("baz@example.com") {
@@ -235,18 +247,21 @@ impl Db for DbMockComplaint {
 
 #[test]
 fn check_db_error() {
-    let settings = create_settings(json!({
-    "enabled": true,
-    "soft": [
-      { "period": "day", "limit": 0 }
-    ],
-    "hard": [
-      { "period": "week", "limit": 0 }
-    ],
-    "complaint": [
-      { "period": "month", "limit": 0 }
-    ]
-  }));
+    let bounce_settings: Json = serde_json::from_str(
+        r#"{
+        "enabled": true,
+        "soft": [
+        { "period": "day", "limit": 0 }
+        ],
+        "hard": [
+        { "period": "week", "limit": 0 }
+        ],
+        "complaint": [
+        { "period": "month", "limit": 0 }
+        ]
+        }"#,
+    ).expect("Unexpected json parsing error.");
+    let settings = create_settings(bounce_settings);
     let db = DbMockError;
     let bounces = Bounces::new(&settings, db);
     match bounces.check("foo@example.com") {
@@ -269,18 +284,21 @@ impl Db for DbMockError {
 
 #[test]
 fn check_no_bounces_with_nonzero_limits() {
-    let settings = create_settings(json!({
-    "enabled": true,
-    "soft": [
-      { "period": "day", "limit": 2 }
-    ],
-    "hard": [
-      { "period": "week", "limit": 2 }
-    ],
-    "complaint": [
-      { "period": "month", "limit": 2 }
-    ]
-  }));
+    let bounce_settings: Json = serde_json::from_str(
+        r#"{
+        "enabled": true,
+        "soft": [
+        { "period": "day", "limit": 2 }
+        ],
+        "hard": [
+        { "period": "week", "limit": 2 }
+        ],
+        "complaint": [
+        { "period": "month", "limit": 2 }
+        ]
+        }"#,
+    ).expect("Unexpected json parsing error.");
+    let settings = create_settings(bounce_settings);
     let db = DbMockNoBounceWithNonZeroLimits;
     let bounces = Bounces::new(&settings, db);
     if let Err(error) = bounces.check("foo@example.com") {
@@ -355,16 +373,19 @@ impl Db for DbMockNoBounceWithNonZeroLimits {
 
 #[test]
 fn check_bounce_with_multiple_limits() {
-    let settings = create_settings(json!({
-    "enabled": true,
-    "soft": [
-      { "period": "2 seconds", "limit": 0 },
-      { "period": "2 minutes", "limit": 1 },
-      { "period": "2 hours", "limit": 2 }
-    ],
-    "hard": [],
-    "complaint": []
-  }));
+    let bounce_settings: Json = serde_json::from_str(
+        r#"{
+        "enabled": true,
+        "soft": [
+        { "period": "2 seconds", "limit": 0 },
+        { "period": "2 minutes", "limit": 1 },
+        { "period": "2 hours", "limit": 2 }
+        ],
+        "hard": [],
+        "complaint": []
+        }"#,
+    ).expect("Unexpected json parsing error.");
+    let settings = create_settings(bounce_settings);
     let db = DbMockBounceWithMultipleLimits;
     let bounces = Bounces::new(&settings, db);
     match bounces.check("foo@example.com") {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@
 //! [queues]: ../fxa_email_queues/index.html
 
 #![feature(assoc_unix_epoch)]
+#![feature(decl_macro)]
 #![feature(plugin)]
 #![feature(try_from)]
 #![feature(type_ascription)]

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -10,7 +10,7 @@ use rocket::{
     http::Status,
     Data, Outcome, Request, State,
 };
-use rocket_contrib::{Json, Value};
+use rocket_contrib::{Json, JsonValue};
 
 use app_errors::{AppError, AppErrorKind, AppResult};
 use auth_db::DbClient;
@@ -87,7 +87,7 @@ fn handler(
     bounces: State<Bounces<DbClient>>,
     message_data: State<MessageData>,
     providers: State<Providers>,
-) -> AppResult<Json<Value>> {
+) -> AppResult<Json<JsonValue>> {
     let email = email?;
 
     let to = email.to.0.as_ref();

--- a/src/send/test.rs
+++ b/src/send/test.rs
@@ -29,7 +29,7 @@ fn setup() -> Client {
         .manage(message_data)
         .manage(providers)
         .mount("/", routes![super::handler])
-        .catch(errors![
+        .catch(catchers![
             app_errors::bad_request,
             app_errors::not_found,
             app_errors::method_not_allowed,


### PR DESCRIPTION
Fixes #111 

In order to do this I had to point our rocket version to the Rocket repo and that introduced some breaking changes which I also fixed in this PR. Mostly they were variable name changes 👍 

Anyways now if you run rocket right `ROCKET_ENV=production` you get no rocket logs.

![screen shot 2018-07-11 at 2 26 26 pm](https://user-images.githubusercontent.com/25176023/42600302-abca5e3c-8516-11e8-9eb9-80c0ec34cbe4.png)

r? @vladikoff @philbooth 
