### PR TITLE
chore(tests): add tests for ses provider and mime message building

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,6 +477,7 @@ dependencies = [
  "rocket_contrib 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)",
  "rusoto_core 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_credential 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_mock 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_ses 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rusoto_sqs 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sendgrid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1302,6 +1303,17 @@ dependencies = [
  "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rusoto_mock"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "chrono 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_core 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2208,6 +2220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rocket_http 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)" = "<none>"
 "checksum rusoto_core 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12daaa6d62d64f6447bf0299ce775f4e05f8e75e5418e817da094b9de04ad22d"
 "checksum rusoto_credential 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "53199d09fd1b7d4f5ac50f4d23106577624238ea77cae2b44eb1d1fc4cd956a4"
+"checksum rusoto_mock 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4eecb9cf02c12eb9276f61589aa2d47ab06d9aa6fa04b2dfdc8a39b6786c8289"
 "checksum rusoto_ses 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "88d4645c94b099369602db7d814b1741f991b3d6821d8076b2ac67824b8cc130"
 "checksum rusoto_sqs 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "995322c1530460a18fadd2f16761f22ba3f4e1fe630e344ca97e81d921abfb00"
 "checksum rust-ini 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ac66e816614e124a692b6ac1b8437237a518c9155a3aacab83a373982630c715"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ rocket_codegen = { git = "https://github.com/SergioBenitez/Rocket", rev="18a91c9
 rocket_contrib = { git = "https://github.com/SergioBenitez/Rocket", rev="18a91c938eb534a410a76137fbf114333ab38643" }
 rusoto_core = ">=0.32.0"
 rusoto_credential = ">=0.11.0"
+rusoto_mock = ">=0.26.0"
 rusoto_ses = ">=0.32.0"
 rusoto_sqs = ">=0.32.0"
 sendgrid = ">=0.7.1"

--- a/src/app_errors/mod.rs
+++ b/src/app_errors/mod.rs
@@ -121,8 +121,8 @@ pub enum AppErrorKind {
     #[fail(display = "Invalid provider name: {}", _0)]
     InvalidProvider(String),
     /// An error for when we get an error from a provider.
-    #[fail(display = "{}", _description)]
-    ProviderError { _name: String, _description: String },
+    #[fail(display = "{}", description)]
+    ProviderError { name: String, description: String },
     /// An error for when we have trouble parsing the email message.
     #[fail(display = "{:?}", _0)]
     EmailParsingError(String),
@@ -130,18 +130,18 @@ pub enum AppErrorKind {
     /// An error for when a bounce violation happens.
     #[fail(display = "Email account sent complaint.")]
     BounceComplaintError {
-        _address: String,
-        _bounce: Option<BounceRecord>,
+        address: String,
+        bounce: Option<BounceRecord>,
     },
     #[fail(display = "Email account soft bounced.")]
     BounceSoftError {
-        _address: String,
-        _bounce: Option<BounceRecord>,
+        address: String,
+        bounce: Option<BounceRecord>,
     },
     #[fail(display = "Email account hard bounced.")]
     BounceHardError {
-        _address: String,
-        _bounce: Option<BounceRecord>,
+        address: String,
+        bounce: Option<BounceRecord>,
     },
 
     /// An error for when an error happens on a request to the db.
@@ -203,32 +203,32 @@ impl AppErrorKind {
         let mut fields = Map::new();
         match self {
             AppErrorKind::ProviderError {
-                ref _name,
-                ref _description,
+                ref name,
+                ..
             } => {
-                fields.insert(String::from("name"), Value::String(format!("{}", _name)));
+                fields.insert(String::from("name"), Value::String(format!("{}", name)));
             }
 
             AppErrorKind::BounceComplaintError {
-                ref _address,
-                ref _bounce,
+                ref address,
+                ref bounce,
             }
             | AppErrorKind::BounceSoftError {
-                ref _address,
-                ref _bounce,
+                ref address,
+                ref bounce,
             }
             | AppErrorKind::BounceHardError {
-                ref _address,
-                ref _bounce,
+                ref address,
+                ref bounce,
             } => {
                 fields.insert(
                     String::from("address"),
-                    Value::String(format!("{}", _address)),
+                    Value::String(format!("{}", address)),
                 );
-                if let Some(_bounce) = _bounce {
+                if let Some(bounce) = bounce {
                     fields.insert(
                         String::from("bounce"),
-                        Value::String(to_string(_bounce).unwrap_or(String::from("{}"))),
+                        Value::String(to_string(bounce).unwrap_or(String::from("{}"))),
                     );
                 }
             }

--- a/src/app_errors/mod.rs
+++ b/src/app_errors/mod.rs
@@ -202,10 +202,7 @@ impl AppErrorKind {
     pub fn additional_fields(&self) -> Map<String, Value> {
         let mut fields = Map::new();
         match self {
-            AppErrorKind::ProviderError {
-                ref name,
-                ..
-            } => {
+            AppErrorKind::ProviderError { ref name, .. } => {
                 fields.insert(String::from("name"), Value::String(format!("{}", name)));
             }
 

--- a/src/bounces/mod.rs
+++ b/src/bounces/mod.rs
@@ -69,16 +69,16 @@ where
                     if is_bounce_violation(*count, bounce.created_at, now, limits) {
                         return match bounce.bounce_type {
                             DbBounceType::Hard => Err(AppErrorKind::BounceHardError {
-                                _address: address.to_string(),
-                                _bounce: Some(bounce.clone()),
+                                address: address.to_string(),
+                                bounce: Some(bounce.clone()),
                             }.into()),
                             DbBounceType::Soft => Err(AppErrorKind::BounceSoftError {
-                                _address: address.to_string(),
-                                _bounce: Some(bounce.clone()),
+                                address: address.to_string(),
+                                bounce: Some(bounce.clone()),
                             }.into()),
                             DbBounceType::Complaint => Err(AppErrorKind::BounceComplaintError {
-                                _address: address.to_string(),
-                                _bounce: Some(bounce.clone()),
+                                address: address.to_string(),
+                                bounce: Some(bounce.clone()),
                             }.into()),
                         };
                     }

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -6,6 +6,8 @@
 
 use std::{boxed::Box, collections::HashMap};
 
+use emailmessage::{header, Mailbox, Message, MultiPart, SinglePart};
+
 use self::{
     mock::MockProvider as Mock, sendgrid::SendgridProvider as Sendgrid, ses::SesProvider as Ses,
     smtp::SmtpProvider as Smtp,
@@ -17,6 +19,8 @@ mod mock;
 mod sendgrid;
 mod ses;
 mod smtp;
+#[cfg(test)]
+mod test;
 
 /// Email headers.
 pub type Headers = HashMap<String, String>;
@@ -31,6 +35,60 @@ trait Provider {
         body_text: &str,
         body_html: Option<&str>,
     ) -> AppResult<String>;
+
+    fn build_multipart_mime(
+        &self,
+        sender: &str,
+        to: &str,
+        cc: &[&str],
+        headers: Option<&Headers>,
+        subject: &str,
+        body_text: &str,
+        body_html: Option<&str>,
+    ) -> AppResult<Message<MultiPart<String>>> {
+        let mut all_headers = header::Headers::new();
+        all_headers.set(header::From(vec![sender.parse::<Mailbox>()?]));
+        all_headers.set(header::To(vec![to.parse::<Mailbox>()?]));
+        all_headers.set(header::Subject(subject.into()));
+        all_headers.set(header::MIME_VERSION_1_0);
+
+        if cc.len() > 0 {
+            let mut parsed_cc: Vec<Mailbox> = Vec::new();
+            for address in cc.iter() {
+                parsed_cc.push(address.parse::<Mailbox>()?)
+            }
+            all_headers.set(header::Cc(parsed_cc))
+        }
+
+        if let Some(headers) = headers {
+            for (name, value) in headers {
+                all_headers.append_raw(name.to_owned(), value.to_owned())
+            }
+        }
+
+        let message: Message<MultiPart<String>> = Message::new().with_headers(all_headers);
+
+        let mut body: MultiPart<String> = MultiPart::alternative().with_singlepart(
+            SinglePart::quoted_printable()
+                .with_header(header::ContentType(
+                    "text/plain; charset=utf8".parse().unwrap(),
+                ))
+                .with_body(body_text.to_owned()),
+        );
+        if let Some(body_html) = body_html {
+            body = body.with_multipart(
+                MultiPart::related().with_singlepart(
+                    SinglePart::eight_bit()
+                        .with_header(header::ContentType(
+                            "text/html; charset=utf8".parse().unwrap(),
+                        ))
+                        .with_body(body_html.to_owned()),
+                ),
+            )
+        }
+
+        Ok(message.with_body(MultiPart::mixed().with_multipart(body)))
+    }
 }
 
 /// Generic provider wrapper.

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -25,6 +25,60 @@ mod test;
 /// Email headers.
 pub type Headers = HashMap<String, String>;
 
+/// Build email MIME message.
+fn build_multipart_mime(
+    sender: &str,
+    to: &str,
+    cc: &[&str],
+    headers: Option<&Headers>,
+    subject: &str,
+    body_text: &str,
+    body_html: Option<&str>,
+) -> AppResult<Message<MultiPart<String>>> {
+    let mut all_headers = header::Headers::new();
+    all_headers.set(header::From(vec![sender.parse::<Mailbox>()?]));
+    all_headers.set(header::To(vec![to.parse::<Mailbox>()?]));
+    all_headers.set(header::Subject(subject.into()));
+    all_headers.set(header::MIME_VERSION_1_0);
+
+    if cc.len() > 0 {
+        let mut parsed_cc: Vec<Mailbox> = Vec::new();
+        for address in cc.iter() {
+            parsed_cc.push(address.parse::<Mailbox>()?)
+        }
+        all_headers.set(header::Cc(parsed_cc))
+    }
+
+    if let Some(headers) = headers {
+        for (name, value) in headers {
+            all_headers.append_raw(name.to_owned(), value.to_owned())
+        }
+    }
+
+    let message: Message<MultiPart<String>> = Message::new().with_headers(all_headers);
+
+    let mut body: MultiPart<String> = MultiPart::alternative().with_singlepart(
+        SinglePart::quoted_printable()
+            .with_header(header::ContentType(
+                "text/plain; charset=utf8".parse().unwrap(),
+            ))
+            .with_body(body_text.to_owned()),
+    );
+    if let Some(body_html) = body_html {
+        body = body.with_multipart(
+            MultiPart::related().with_singlepart(
+                SinglePart::eight_bit()
+                    .with_header(header::ContentType(
+                        "text/html; charset=utf8".parse().unwrap(),
+                    ))
+                    .with_body(body_html.to_owned()),
+            ),
+        )
+    }
+
+    Ok(message.with_body(MultiPart::mixed().with_multipart(body)))
+}
+
 trait Provider {
     fn send(
         &self,
@@ -35,60 +89,6 @@ trait Provider {
         body_text: &str,
         body_html: Option<&str>,
     ) -> AppResult<String>;
-
-    fn build_multipart_mime(
-        &self,
-        sender: &str,
-        to: &str,
-        cc: &[&str],
-        headers: Option<&Headers>,
-        subject: &str,
-        body_text: &str,
-        body_html: Option<&str>,
-    ) -> AppResult<Message<MultiPart<String>>> {
-        let mut all_headers = header::Headers::new();
-        all_headers.set(header::From(vec![sender.parse::<Mailbox>()?]));
-        all_headers.set(header::To(vec![to.parse::<Mailbox>()?]));
-        all_headers.set(header::Subject(subject.into()));
-        all_headers.set(header::MIME_VERSION_1_0);
-
-        if cc.len() > 0 {
-            let mut parsed_cc: Vec<Mailbox> = Vec::new();
-            for address in cc.iter() {
-                parsed_cc.push(address.parse::<Mailbox>()?)
-            }
-            all_headers.set(header::Cc(parsed_cc))
-        }
-
-        if let Some(headers) = headers {
-            for (name, value) in headers {
-                all_headers.append_raw(name.to_owned(), value.to_owned())
-            }
-        }
-
-        let message: Message<MultiPart<String>> = Message::new().with_headers(all_headers);
-
-        let mut body: MultiPart<String> = MultiPart::alternative().with_singlepart(
-            SinglePart::quoted_printable()
-                .with_header(header::ContentType(
-                    "text/plain; charset=utf8".parse().unwrap(),
-                ))
-                .with_body(body_text.to_owned()),
-        );
-        if let Some(body_html) = body_html {
-            body = body.with_multipart(
-                MultiPart::related().with_singlepart(
-                    SinglePart::eight_bit()
-                        .with_header(header::ContentType(
-                            "text/html; charset=utf8".parse().unwrap(),
-                        ))
-                        .with_body(body_html.to_owned()),
-                ),
-            )
-        }
-
-        Ok(message.with_body(MultiPart::mixed().with_multipart(body)))
-    }
 }
 
 /// Generic provider wrapper.

--- a/src/providers/sendgrid.rs
+++ b/src/providers/sendgrid.rs
@@ -85,8 +85,8 @@ impl Provider for SendgridProvider {
                         .and_then(|raw_header| raw_header.one())
                         .ok_or(
                             AppErrorKind::ProviderError {
-                                _name: String::from("Sendgrid"),
-                                _description: String::from(
+                                name: String::from("Sendgrid"),
+                                description: String::from(
                                     "Missing or duplicate X-Message-Id header in Sendgrid response",
                                 ),
                             }.into(),
@@ -95,8 +95,8 @@ impl Provider for SendgridProvider {
                         .map(|message_id| message_id.to_string())
                 } else {
                     Err(AppErrorKind::ProviderError {
-                        _name: String::from("Sendgrid"),
-                        _description: format!("Unsuccesful response status: {}", status),
+                        name: String::from("Sendgrid"),
+                        description: format!("Unsuccesful response status: {}", status),
                     }.into())
                 }
             })
@@ -106,8 +106,8 @@ impl Provider for SendgridProvider {
 impl From<SendgridError> for AppError {
     fn from(error: SendgridError) -> AppError {
         AppErrorKind::ProviderError {
-            _name: String::from("Sendgrid"),
-            _description: format!("{:?}", error),
+            name: String::from("Sendgrid"),
+            description: format!("{:?}", error),
         }.into()
     }
 }
@@ -115,8 +115,8 @@ impl From<SendgridError> for AppError {
 impl From<Utf8Error> for AppError {
     fn from(error: Utf8Error) -> AppError {
         AppErrorKind::ProviderError {
-            _name: String::from("Sendgrid"),
-            _description: format!("Failed to decode string as UTF-8: {:?}", error),
+            name: String::from("Sendgrid"),
+            description: format!("Failed to decode string as UTF-8: {:?}", error),
         }.into()
     }
 }

--- a/src/providers/ses.rs
+++ b/src/providers/ses.rs
@@ -84,8 +84,8 @@ impl From<String> for AppError {
 impl From<SendRawEmailError> for AppError {
     fn from(error: SendRawEmailError) -> AppError {
         AppErrorKind::ProviderError {
-            _name: String::from("SES"),
-            _description: format!("{:?}", error),
+            name: String::from("SES"),
+            description: format!("{:?}", error),
         }.into()
     }
 }

--- a/src/providers/ses/mod.rs
+++ b/src/providers/ses/mod.rs
@@ -9,9 +9,12 @@ use rusoto_core::{reactor::RequestDispatcher, Region};
 use rusoto_credential::StaticProvider;
 use rusoto_ses::{RawMessage, SendRawEmailError, SendRawEmailRequest, Ses, SesClient};
 
-use super::{Headers, Provider};
+use super::{build_multipart_mime, Headers, Provider};
 use app_errors::{AppError, AppErrorKind, AppResult};
 use settings::Settings;
+
+#[cfg(test)]
+mod test;
 
 pub struct SesProvider {
     client: Box<Ses>,
@@ -52,15 +55,8 @@ impl Provider for SesProvider {
         body_text: &str,
         body_html: Option<&str>,
     ) -> AppResult<String> {
-        let message = self.build_multipart_mime(
-            &self.sender,
-            to,
-            cc,
-            headers,
-            subject,
-            body_text,
-            body_html,
-        )?;
+        let message =
+            build_multipart_mime(&self.sender, to, cc, headers, subject, body_text, body_html)?;
         let encoded_message = encode(&format!("{}", message));
         let mut request = SendRawEmailRequest::default();
         request.raw_message = RawMessage {

--- a/src/providers/ses/test.rs
+++ b/src/providers/ses/test.rs
@@ -1,0 +1,63 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+
+extern crate rusoto_mock;
+
+use self::rusoto_mock::{MockCredentialsProvider, MockRequestDispatcher};
+use rusoto_core::Region;
+use rusoto_ses::SesClient;
+
+use super::{Provider, SesProvider};
+
+#[test]
+fn ses_send_handles_ok_response() {
+    let body = r#"
+        <SendRawEmailResponse xmlns="http://ses.amazonaws.com/doc/2010-12-01/">
+            <SendRawEmailResult>
+                <MessageId>woopwoop</MessageId>
+            </SendRawEmailResult>
+            <ResponseMetadata>
+                <RequestId>random-id</RequestId>
+            </ResponseMetadata>
+        </SendRawEmailResponse>
+    "#;
+    let mock_dispatcher = MockRequestDispatcher::with_status(200).with_body(&body);
+    let mock_ses = SesProvider {
+        client: Box::new(SesClient::new(
+            mock_dispatcher,
+            MockCredentialsProvider,
+            Region::SaEast1,
+        )),
+        sender: "Foo Bar <a@a.com>".to_string(),
+    };
+    match mock_ses.send("b@b.com", &[], None, "subject", "body", None) {
+        Ok(response) => assert_eq!("woopwoop", response),
+        Err(error) => assert!(false, format!("{}", error)),
+    }
+}
+
+#[test]
+fn ses_send_handles_error_response() {
+    let body = "FREAKOUT";
+    let mock_dispatcher = MockRequestDispatcher::with_status(500).with_body(&body);
+    let mock_ses = SesProvider {
+        client: Box::new(SesClient::new(
+            mock_dispatcher,
+            MockCredentialsProvider,
+            Region::SaEast1,
+        )),
+        sender: "Foo Bar <a@a.com>".to_string(),
+    };
+    match mock_ses.send("b@b.com", &[], None, "subject", "body", None) {
+        Ok(_) => assert!(false, "Request should have failed."),
+        Err(error) => {
+            let error = error.json();
+            assert_eq!("500", &error["code"]);
+            assert_eq!("104", &error["errno"]);
+            assert_eq!("Internal Server Error", &error["error"]);
+            assert_eq!("Unknown(\"FREAKOUT\")", &error["message"]);
+            assert_eq!("SES", &error["name"]);
+        }
+    }
+}

--- a/src/providers/smtp.rs
+++ b/src/providers/smtp.rs
@@ -72,8 +72,8 @@ impl Provider for SmtpProvider {
             Ok(format!("{}", &result.code))
         } else {
             Err(AppErrorKind::ProviderError {
-                _name: String::from("Smtp"),
-                _description: format!("{:?}", result),
+                name: String::from("Smtp"),
+                description: format!("{:?}", result),
             }.into())
         }
     }
@@ -82,8 +82,8 @@ impl Provider for SmtpProvider {
 impl From<SmtpError> for AppError {
     fn from(error: SmtpError) -> AppError {
         AppErrorKind::ProviderError {
-            _name: String::from("Smtp"),
-            _description: format!("{:?}", error),
+            name: String::from("Smtp"),
+            description: format!("{:?}", error),
         }.into()
     }
 }
@@ -91,8 +91,8 @@ impl From<SmtpError> for AppError {
 impl From<EmailError> for AppError {
     fn from(error: EmailError) -> AppError {
         AppErrorKind::ProviderError {
-            _name: String::from("Smtp"),
-            _description: format!("{:?}", error),
+            name: String::from("Smtp"),
+            description: format!("{:?}", error),
         }.into()
     }
 }

--- a/src/providers/test.rs
+++ b/src/providers/test.rs
@@ -1,0 +1,111 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::collections::HashMap;
+
+use super::{mock::MockProvider, Provider};
+
+#[test]
+fn build_mime_without_optional_data() {
+    let mock = MockProvider {};
+    let message = mock
+        .build_multipart_mime("a@a.com", "b@b.com", &[], None, "subject", "body", None)
+        .unwrap();
+    let message: Vec<String> = format!("{}", message)
+        .split("\r\n")
+        .map(|s| s.to_owned())
+        .collect();
+    assert_eq!("From: a@a.com", &message[0]);
+    assert_eq!("To: b@b.com", &message[1]);
+    assert_eq!("Subject: subject", &message[2]);
+    assert_eq!("MIME-Version: 1.0", &message[3]);
+    assert_eq!("Content-Transfer-Encoding: quoted-printable", &message[10]);
+    assert_eq!("Content-Type: text/plain; charset=utf8", &message[11]);
+    assert_eq!("body", &message[13]);
+}
+
+#[test]
+fn build_mime_with_cc_headers() {
+    let mock = MockProvider {};
+    let message =
+        mock.build_multipart_mime(
+            "a@a.com",
+            "b@b.com",
+            &["c@c.com", "d@d.com"],
+            None,
+            "subject",
+            "body",
+            None,
+        ).unwrap();
+    let message: Vec<String> = format!("{}", message)
+        .split("\r\n")
+        .map(|s| s.to_owned())
+        .collect();
+    assert_eq!("From: a@a.com", &message[0]);
+    assert_eq!("To: b@b.com", &message[1]);
+    assert_eq!("Subject: subject", &message[2]);
+    assert_eq!("MIME-Version: 1.0", &message[3]);
+    assert_eq!("Cc: c@c.com, d@d.com", &message[4]);
+    assert_eq!("Content-Transfer-Encoding: quoted-printable", &message[11]);
+    assert_eq!("Content-Type: text/plain; charset=utf8", &message[12]);
+    assert_eq!("body", &message[14]);
+}
+
+#[test]
+fn build_mime_with_custom_headers() {
+    let mock = MockProvider {};
+    let mut custom_headers = HashMap::new();
+    custom_headers.insert("x-foo".to_string(), "bar".to_string());
+    let message =
+        mock.build_multipart_mime(
+            "a@a.com",
+            "b@b.com",
+            &[],
+            Some(&custom_headers),
+            "subject",
+            "body",
+            None,
+        ).unwrap();
+    let message: Vec<String> = format!("{}", message)
+        .split("\r\n")
+        .map(|s| s.to_owned())
+        .collect();
+    assert_eq!("From: a@a.com", &message[0]);
+    assert_eq!("To: b@b.com", &message[1]);
+    assert_eq!("Subject: subject", &message[2]);
+    assert_eq!("MIME-Version: 1.0", &message[3]);
+    assert_eq!("x-foo: bar", &message[4]);
+    assert_eq!("Content-Transfer-Encoding: quoted-printable", &message[11]);
+    assert_eq!("Content-Type: text/plain; charset=utf8", &message[12]);
+    assert_eq!("body", &message[14]);
+}
+
+#[test]
+fn build_mime_with_body_html() {
+    let mock = MockProvider {};
+    let message =
+        mock.build_multipart_mime(
+            "a@a.com",
+            "b@b.com",
+            &[],
+            None,
+            "subject",
+            "body",
+            Some("<p>body</p>"),
+        ).unwrap();
+    let message: Vec<String> = format!("{}", message)
+        .split("\r\n")
+        .map(|s| s.to_owned())
+        .collect();
+    assert_eq!("From: a@a.com", &message[0]);
+    assert_eq!("To: b@b.com", &message[1]);
+    assert_eq!("Subject: subject", &message[2]);
+    assert_eq!("MIME-Version: 1.0", &message[3]);
+    assert_eq!("Content-Transfer-Encoding: quoted-printable", &message[10]);
+    assert_eq!("Content-Type: text/plain; charset=utf8", &message[11]);
+    assert_eq!("body", &message[13]);
+    assert_eq!("Content-Transfer-Encoding: 8bit", &message[18]);
+    assert_eq!("Content-Type: text/html; charset=utf8", &message[19]);
+    assert_eq!("<p>body</p>", &message[21]);
+}

--- a/src/providers/test.rs
+++ b/src/providers/test.rs
@@ -4,14 +4,12 @@
 
 use std::collections::HashMap;
 
-use super::{mock::MockProvider, Provider};
+use super::build_multipart_mime;
 
 #[test]
 fn build_mime_without_optional_data() {
-    let mock = MockProvider {};
-    let message = mock
-        .build_multipart_mime("a@a.com", "b@b.com", &[], None, "subject", "body", None)
-        .unwrap();
+    let message =
+        build_multipart_mime("a@a.com", "b@b.com", &[], None, "subject", "body", None).unwrap();
     let message: Vec<String> = format!("{}", message)
         .split("\r\n")
         .map(|s| s.to_owned())
@@ -27,17 +25,15 @@ fn build_mime_without_optional_data() {
 
 #[test]
 fn build_mime_with_cc_headers() {
-    let mock = MockProvider {};
-    let message =
-        mock.build_multipart_mime(
-            "a@a.com",
-            "b@b.com",
-            &["c@c.com", "d@d.com"],
-            None,
-            "subject",
-            "body",
-            None,
-        ).unwrap();
+    let message = build_multipart_mime(
+        "a@a.com",
+        "b@b.com",
+        &["c@c.com", "d@d.com"],
+        None,
+        "subject",
+        "body",
+        None,
+    ).unwrap();
     let message: Vec<String> = format!("{}", message)
         .split("\r\n")
         .map(|s| s.to_owned())
@@ -54,19 +50,17 @@ fn build_mime_with_cc_headers() {
 
 #[test]
 fn build_mime_with_custom_headers() {
-    let mock = MockProvider {};
     let mut custom_headers = HashMap::new();
     custom_headers.insert("x-foo".to_string(), "bar".to_string());
-    let message =
-        mock.build_multipart_mime(
-            "a@a.com",
-            "b@b.com",
-            &[],
-            Some(&custom_headers),
-            "subject",
-            "body",
-            None,
-        ).unwrap();
+    let message = build_multipart_mime(
+        "a@a.com",
+        "b@b.com",
+        &[],
+        Some(&custom_headers),
+        "subject",
+        "body",
+        None,
+    ).unwrap();
     let message: Vec<String> = format!("{}", message)
         .split("\r\n")
         .map(|s| s.to_owned())
@@ -83,17 +77,15 @@ fn build_mime_with_custom_headers() {
 
 #[test]
 fn build_mime_with_body_html() {
-    let mock = MockProvider {};
-    let message =
-        mock.build_multipart_mime(
-            "a@a.com",
-            "b@b.com",
-            &[],
-            None,
-            "subject",
-            "body",
-            Some("<p>body</p>"),
-        ).unwrap();
+    let message = build_multipart_mime(
+        "a@a.com",
+        "b@b.com",
+        &[],
+        None,
+        "subject",
+        "body",
+        Some("<p>body</p>"),
+    ).unwrap();
     let message: Vec<String> = format!("{}", message)
         .split("\r\n")
         .map(|s| s.to_owned())


### PR DESCRIPTION
Fixes #21 

Gets all these done: https://github.com/mozilla/fxa-email-service/issues/21#issuecomment-402312872 

I put the mime message building as a default for the `Provider` trait because it is not something exclusive to the SES provider and might be useful for other providers we might implement in the future and it made it easier for testing.

Also, I removed the underline from all error properties, there was no reason for them to be there and it made it more confusing because it seemed like they had the underline because they were not being used... Let me know if you guys think that should be extracted into it's own PR.

Anyways, r? @philbooth @vladikoff 