### PR TITLE
refactor(settings): drop NODE_ENV and add LOG_LEVEL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ COPY --from=builder /app/bin /app/bin
 WORKDIR /app/bin
 USER app
 
+ENV FXA_EMAIL_ENV production
 ENV ROCKET_ENV production
 
 CMD ["/app/bin/fxa_email_send"]

--- a/config/default.json
+++ b/config/default.json
@@ -21,7 +21,10 @@
   },
   "hmackey": "YOU MUST CHANGE ME",
   "host": "127.0.0.1",
-  "logging": "mozlog",
+  "log": {
+    "level": "off",
+    "format": "mozlog"
+  },
   "port": 8001,
   "provider": "ses",
   "redis": {

--- a/config/dev.json
+++ b/config/dev.json
@@ -1,5 +1,8 @@
 {
-  "logging": "pretty",
+  "log": {
+    "level": "normal",
+    "format": "pretty"
+  },
   "provider": "smtp",
   "smtp": {
     "port": 9999

--- a/config/test.json
+++ b/config/test.json
@@ -1,3 +1,0 @@
-{
-    "logging": "null"
-}

--- a/scripts/test_standalone.sh
+++ b/scripts/test_standalone.sh
@@ -2,8 +2,8 @@
 
 export RUST_BACKTRACE=1
 
-if [ -z "$NODE_ENV" ]; then
-  export NODE_ENV=test
+if [ -z "$FXA_EMAIL_LOG_FORMAT" ]; then
+  export FXA_EMAIL_LOG_FORMAT=null
 fi
 
 cargo test -- --test-threads=1

--- a/scripts/test_with_authdb.sh
+++ b/scripts/test_with_authdb.sh
@@ -17,8 +17,8 @@ fi
 
 sleep 2
 
-if [ -z "$NODE_ENV" ]; then
-  export NODE_ENV=test
+if [ -z "$FXA_EMAIL_LOG_FORMAT" ]; then
+  export FXA_EMAIL_LOG_FORMAT=null
 fi
 
 export RUST_BACKTRACE=1

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -73,7 +73,7 @@ pub struct MozlogLogger(slog::Logger);
 impl MozlogLogger {
     /// Construct a logger.
     pub fn new(settings: &Settings) -> Result<MozlogLogger, Error> {
-        let logger = match &*settings.logging.0.as_ref() {
+        let logger = match &*settings.log.format.0.as_ref() {
             "mozlog" => {
                 let drain = MozLogJson::new(io::stdout())
                     .logger_name(LOGGER_NAME.to_owned())

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -63,10 +63,12 @@ deserialize_and_validate! {
     (AwsSecret, aws_secret, "AWS secret key"),
     /// Base URI type.
     (BaseUri, base_uri, "base URI"),
+    /// Env type.
+    (Env, env, "'dev', 'staging', 'production' or 'test'"),
     /// Host name or IP address type.
     (Host, host, "host name or IP address"),
     /// Logging level type.
-    (LoggingLevel, logging_level, "'normal', 'debug'm 'critical' or 'off'"),
+    (LoggingLevel, logging_level, "'normal', 'debug', 'critical' or 'off'"),
     /// Logging format type.
     (LoggingFormat, logging_format, "'mozlog', 'pretty' or 'null'"),
     /// Email provider type.
@@ -278,6 +280,10 @@ pub struct Settings {
     /// will fail with a `429` error.
     pub bouncelimits: BounceLimits,
 
+    /// The env sets which environment we are in.
+    /// It defaults to `dev` if not set.
+    pub env: Env,
+
     /// The HMAC key to use internally
     /// for hashing message ids.
     /// This is sensitive data
@@ -329,12 +335,8 @@ impl Settings {
     ///
     ///   1. Environment variables: `$FXA_EMAIL_<UPPERCASE_KEY_NAME>`
     ///   2. File: `config/local.json`
-    ///   3. File: `config/<$NODE_ENV>.json`
+    ///   3. File: `config/<$FXA_EMAIL_ENV>.json`
     ///   4. File: `config/default.json`
-    ///
-    /// `$NODE_ENV` is used so that this service automatically picks up the
-    /// appropriate state from our existing node.js ecosystem, without needing
-    /// to manage an extra environment variable.
     ///
     /// Immediately before returning, the parsed config object will be logged to
     /// the console.
@@ -343,9 +345,12 @@ impl Settings {
 
         config.merge(File::with_name("config/default"))?;
 
-        if let Ok(node_env) = env::var("NODE_ENV") {
-            config.merge(File::with_name(&format!("config/{}", node_env)).required(false))?;
-        }
+        let current_env = match env::var("FXA_EMAIL_ENV") {
+            Ok(env) => env,
+            _ => String::from("dev"),
+        };
+        config.merge(File::with_name(&format!("config/{}", current_env)).required(false))?;
+        config.set_default("env", "dev")?;
 
         config.merge(File::with_name("config/local").required(false))?;
         let env = Environment::with_prefix("fxa_email");
@@ -353,10 +358,8 @@ impl Settings {
 
         match config.try_into::<Settings>() {
             Ok(settings) => {
-                if let Ok(node_env) = env::var("NODE_ENV") {
-                    if node_env == "production" && &settings.hmackey == "YOU MUST CHANGE ME" {
-                        panic!("Please set a valid HMAC key.")
-                    }
+                if current_env == "production" && &settings.hmackey == "YOU MUST CHANGE ME" {
+                    panic!("Please set a valid HMAC key.")
                 }
 
                 let logger =
@@ -368,19 +371,19 @@ impl Settings {
         }
     }
 
-    /// Create rocket configuration based on the `NODE_ENV` environment
-    /// variable. Defaults to `dev` mode if `NODE_ENV` is not set.
+    /// Create rocket configuration based on the environment
+    /// variable. Defaults to `dev` mode if `FXA_EMAIL_ENV` is not set.
     pub fn build_rocket_config(&self) -> Result<RocketConfig, RocketConfigError> {
         let log_level = match self.log.level.0.as_str() {
             "debug" => RocketLoggingLevel::Debug,
             "critical" => RocketLoggingLevel::Critical,
             "off" => RocketLoggingLevel::Off,
-            _ => RocketLoggingLevel::Normal
+            _ => RocketLoggingLevel::Normal,
         };
-        let rocket_config = match env::var("NODE_ENV").as_ref().map(String::as_ref) {
-            Ok("production") => RocketEnvironment::Production,
-            Ok("staging") => RocketEnvironment::Staging,
-            _ => RocketEnvironment::Development
+        let rocket_config = match self.env.0.as_str() {
+            "production" => RocketEnvironment::Production,
+            "staging" => RocketEnvironment::Staging,
+            _ => RocketEnvironment::Development,
         };
         RocketConfig::build(rocket_config)
             .address(self.host.0.clone())

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -30,7 +30,7 @@ lazy_static! {
     ).unwrap();
     static ref ENV: Regex = Regex::new("^(?:dev|staging|production|test)$").unwrap();
     static ref HOST_FORMAT: Regex = Regex::new("^[A-Za-z0-9-]+(?:\\.[A-Za-z0-9-]+)*$").unwrap();
-    static ref LOGGING_LEVEL: Regex = Regex::new("^(?:normal|debug|critial|off)$").unwrap();
+    static ref LOGGING_LEVEL: Regex = Regex::new("^(?:normal|debug|critical|off)$").unwrap();
     static ref LOGGING_FORMAT: Regex = Regex::new("^(?:mozlog|pretty|null)$").unwrap();
     static ref PROVIDER_FORMAT: Regex = Regex::new("^(?:mock|sendgrid|ses|smtp|socketlabs)$").unwrap();
     static ref SENDER_NAME_FORMAT: Regex =

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -29,6 +29,7 @@ lazy_static! {
         "^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]{1,64}@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,253}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,253}[a-zA-Z0-9])?)+$"
     ).unwrap();
     static ref HOST_FORMAT: Regex = Regex::new("^[A-Za-z0-9-]+(?:\\.[A-Za-z0-9-]+)*$").unwrap();
+    static ref LOGGING_LEVEL: Regex = Regex::new("^(?:normal|debug|critial|off)$").unwrap();
     static ref LOGGING_FORMAT: Regex = Regex::new("^(?:mozlog|pretty|null)$").unwrap();
     static ref PROVIDER_FORMAT: Regex = Regex::new("^(?:mock|sendgrid|ses|smtp|socketlabs)$").unwrap();
     static ref SENDER_NAME_FORMAT: Regex =
@@ -69,7 +70,12 @@ pub fn host(value: &str) -> bool {
 }
 
 /// Validate logging level.
-pub fn logging(value: &str) -> bool {
+pub fn logging_level(value: &str) -> bool {
+    LOGGING_LEVEL.is_match(value)
+}
+
+/// Validate logging format.
+pub fn logging_format(value: &str) -> bool {
     LOGGING_FORMAT.is_match(value)
 }
 

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -28,6 +28,7 @@ lazy_static! {
     static ref EMAIL_ADDRESS_FORMAT: Regex = Regex::new(
         "^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]{1,64}@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,253}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,253}[a-zA-Z0-9])?)+$"
     ).unwrap();
+    static ref ENV: Regex = Regex::new("^(?:dev|staging|production|test)$").unwrap();
     static ref HOST_FORMAT: Regex = Regex::new("^[A-Za-z0-9-]+(?:\\.[A-Za-z0-9-]+)*$").unwrap();
     static ref LOGGING_LEVEL: Regex = Regex::new("^(?:normal|debug|critial|off)$").unwrap();
     static ref LOGGING_FORMAT: Regex = Regex::new("^(?:mozlog|pretty|null)$").unwrap();
@@ -62,6 +63,11 @@ pub fn base_uri(value: &str) -> bool {
 /// Validate an email address.
 pub fn email_address(value: &str) -> bool {
     value.len() < 254 && EMAIL_ADDRESS_FORMAT.is_match(value)
+}
+
+/// Validate env.
+pub fn env(value: &str) -> bool {
+    ENV.is_match(value)
 }
 
 /// Validate a host name or IP address.

--- a/src/validate/test.rs
+++ b/src/validate/test.rs
@@ -126,10 +126,36 @@ fn invalid_email_address() {
 }
 
 #[test]
+fn env() {
+    assert!(validate::env("test"));
+    assert!(validate::env("dev"));
+    assert!(validate::env("staging"));
+    assert!(validate::env("production"));
+    assert_eq!(false, validate::env("something else"));
+}
+
+#[test]
 fn host() {
     assert!(validate::host("foo"));
     assert!(validate::host("foo.bar"));
     assert!(validate::host("127.0.0.1"));
+}
+
+#[test]
+fn logging_level() {
+    assert!(validate::logging_level("normal"));
+    assert!(validate::logging_level("debug"));
+    assert!(validate::logging_level("critical"));
+    assert!(validate::logging_level("off"));
+    assert_eq!(false, validate::logging_level("something else"));
+}
+
+#[test]
+fn logging_format() {
+    assert!(validate::logging_format("mozlog"));
+    assert!(validate::logging_format("pretty"));
+    assert!(validate::logging_format("null"));
+    assert_eq!(false, validate::logging_format("something else"));
 }
 
 #[test]


### PR DESCRIPTION
Fixes #138 
Connects to #139 

I did this in two different commits on purpose, so that if we wanna keep using `NODE_ENV` we can remove all the code that removes it by resetting to the first commit in this PR. By the way, I had it default to `dev` in case `FXA_EMAIL_ENV` is not set, I'm not sure this is expected behaviour.

Anyways, I added the `FXA_EMAIL_LOG_LEVEL` variable and changed the `FXA_EMAIL_LOGGING` one to `FXA_EMAIL_LOG_FORMAT`. That is getting a little confusing in my opinion, though. This is what is happening right now:

- `FXA_EMAIL_LOG_LEVEL` : sets the rocket logging level, and does nothing to our logs.
- `FXA_EMAIL_LOG_FORMAT`: sets our logs formatting style. One of the options is `null`, though. Which depending on how you look at it, is a logging level and not formatting.

Let me know what you think and if you have better ways to do this.

r? @jrgm @vladikoff @philbooth 