### PR TITLE
chore(tests): add tests for request unicode handling

### DIFF
--- a/src/send/test.rs
+++ b/src/send/test.rs
@@ -123,6 +123,82 @@ fn without_optional_data() {
 }
 
 #[test]
+fn unicode_email_field() {
+    let client = setup();
+
+    let mut response = client
+        .post("/send")
+        .header(ContentType::JSON)
+        .body(
+            r#"{
+      "to": "시험@example.com",
+      "subject": "bar",
+      "body": {
+        "text": "baz"
+      },
+      "provider": "mock"
+    }"#,
+        )
+        .dispatch();
+
+    assert_eq!(response.status(), Status::Ok);
+
+    let body = response.body().unwrap().into_string().unwrap();
+    assert_eq!(body, json!({ "messageId": "mock:deadbeef" }).to_string());
+}
+
+#[test]
+fn unicode_message_body() {
+    let client = setup();
+
+    let mut response = client
+        .post("/send")
+        .header(ContentType::JSON)
+        .body(
+            r#"{
+      "to": "foo@example.com",
+      "subject": "bar",
+      "body": {
+        "text": "🦀 시험 🦀",
+        "html": "<p>🦀 시험 🦀</p>"
+      },
+      "provider": "mock"
+    }"#,
+        )
+        .dispatch();
+
+    assert_eq!(response.status(), Status::Ok);
+
+    let body = response.body().unwrap().into_string().unwrap();
+    assert_eq!(body, json!({ "messageId": "mock:deadbeef" }).to_string());
+}
+
+#[test]
+fn unicode_message_subject() {
+    let client = setup();
+
+    let mut response = client
+        .post("/send")
+        .header(ContentType::JSON)
+        .body(
+            r#"{
+      "to": "foo@example.com",
+      "subject": "🦀 시험 🦀",
+      "body": {
+        "text": "baz"
+      },
+      "provider": "mock"
+    }"#,
+        )
+        .dispatch();
+
+    assert_eq!(response.status(), Status::Ok);
+
+    let body = response.body().unwrap().into_string().unwrap();
+    assert_eq!(body, json!({ "messageId": "mock:deadbeef" }).to_string());
+}
+
+#[test]
 fn missing_to_field() {
     let client = setup();
 

--- a/src/validate/mod.rs
+++ b/src/validate/mod.rs
@@ -23,21 +23,21 @@ lazy_static! {
     static ref AWS_ACCESS_FORMAT: Regex = Regex::new("^[A-Z0-9]+$").unwrap();
     static ref AWS_SECRET_FORMAT: Regex = Regex::new("^[A-Za-z0-9+/=]+$").unwrap();
     static ref BASE_URI_FORMAT: Regex = Regex::new(
-        "^https?://[A-Za-z0-9-]+(?:\\.[A-Za-z0-9-]+)*(?::[0-9]+)?/(?:[A-Za-z0-9-]+/)*$"
+        r"^https?://[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*(?::[0-9]+)?/(?:[A-Za-z0-9-]+/)*$"
     ).unwrap();
     static ref EMAIL_ADDRESS_FORMAT: Regex = Regex::new(
-        "^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]{1,64}@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,253}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,253}[a-zA-Z0-9])?)+$"
+        r"^[a-zA-Z0-9.\pL\pN!#$%&’*+/=?^_`{|}~-]{1,64}@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,253}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,253}[a-zA-Z0-9])?)+$"
     ).unwrap();
-    static ref ENV: Regex = Regex::new("^(?:dev|staging|production|test)$").unwrap();
-    static ref HOST_FORMAT: Regex = Regex::new("^[A-Za-z0-9-]+(?:\\.[A-Za-z0-9-]+)*$").unwrap();
-    static ref LOGGING_LEVEL: Regex = Regex::new("^(?:normal|debug|critical|off)$").unwrap();
-    static ref LOGGING_FORMAT: Regex = Regex::new("^(?:mozlog|pretty|null)$").unwrap();
-    static ref PROVIDER_FORMAT: Regex = Regex::new("^(?:mock|sendgrid|ses|smtp|socketlabs)$").unwrap();
+    static ref ENV: Regex = Regex::new(r"^(?:dev|staging|production|test)$").unwrap();
+    static ref HOST_FORMAT: Regex = Regex::new(r"^[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*$").unwrap();
+    static ref LOGGING_LEVEL: Regex = Regex::new(r"^(?:normal|debug|critical|off)$").unwrap();
+    static ref LOGGING_FORMAT: Regex = Regex::new(r"^(?:mozlog|pretty|null)$").unwrap();
+    static ref PROVIDER_FORMAT: Regex = Regex::new(r"^(?:mock|sendgrid|ses|smtp|socketlabs)$").unwrap();
     static ref SENDER_NAME_FORMAT: Regex =
-        Regex::new("^[A-Za-z0-9-]+(?: [A-Za-z0-9-]+)*$").unwrap();
+        Regex::new(r"^[A-Za-z0-9-]+(?: [A-Za-z0-9-]+)*$").unwrap();
     static ref SENDGRID_API_KEY_FORMAT: Regex = Regex::new("^[A-Za-z0-9._-]+$").unwrap();
     static ref SQS_URL_FORMAT: Regex =
-        Regex::new("^https://sqs\\.[a-z0-9-]+\\.amazonaws\\.com/[0-9]+/[A-Za-z0-9-]+$").unwrap();
+        Regex::new(r"^https://sqs\.[a-z0-9-]+\.amazonaws\.com/[0-9]+/[A-Za-z0-9-]+$").unwrap();
 }
 
 /// Validate an AWS region.

--- a/src/validate/test.rs
+++ b/src/validate/test.rs
@@ -89,6 +89,7 @@ fn invalid_base_uri() {
 
 #[test]
 fn email_address() {
+    assert!(validate::email_address("٢fooΔ@example.com"));
     assert!(validate::email_address("foo@example.com"));
     assert!(validate::email_address("foo.bar@example.com"));
     assert!(validate::email_address("foo+bar@example.com"));


### PR DESCRIPTION
Fixes #9 

I just added some simple unicode tests for email address, subject and body.

I also added unicode character patterns in our email address regex, because the `.` alone didn't match for some reason...

r? @philbooth @vladikoff 