### PR TITLE
chore(deps): update rocket, failure, rusoto and rust versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
   - redis-server
 cache: cargo
 rust:
-  - nightly-2018-07-14
+  - nightly-2018-08-06
 branches:
   only:
     - master

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,7 +171,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "cookie"
 version = "0.11.0-dev"
-source = "git+https://github.com/alexcrichton/cookie-rs?rev=0365a18#0365a18e4518e498ac6a508dab6b006add7f162e"
+source = "git+https://github.com/alexcrichton/cookie-rs?rev=f191ca50#f191ca50cc91a4bf268b7eb254ebc78b73a94ffc"
 dependencies = [
  "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ring 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -258,11 +258,49 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "derive_utils"
+version = "0.1.0"
+source = "git+https://github.com/SergioBenitez/derive-utils?rev=160da392#160da39233d19e6302272d409a0aea14932b25f2"
+dependencies = [
+ "derive_utils_codegen 0.1.0 (git+https://github.com/SergioBenitez/derive-utils?rev=160da392)",
+ "derive_utils_core 0.1.0 (git+https://github.com/SergioBenitez/derive-utils?rev=160da392)",
+]
+
+[[package]]
+name = "derive_utils_codegen"
+version = "0.1.0"
+source = "git+https://github.com/SergioBenitez/derive-utils?rev=160da392#160da39233d19e6302272d409a0aea14932b25f2"
+dependencies = [
+ "derive_utils_core 0.1.0 (git+https://github.com/SergioBenitez/derive-utils?rev=160da392)",
+ "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "derive_utils_core"
+version = "0.1.0"
+source = "git+https://github.com/SergioBenitez/derive-utils?rev=160da392#160da39233d19e6302272d409a0aea14932b25f2"
+dependencies = [
+ "bitflags 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "digest"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "dirs"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -388,26 +426,32 @@ dependencies = [
 
 [[package]]
 name = "failure"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "failure_derive"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
- "synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "fake-simd"
 version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "fnv"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -459,7 +503,7 @@ dependencies = [
  "chrono 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "config 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "emailmessage 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -472,14 +516,14 @@ dependencies = [
  "redis 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)",
- "rocket_codegen 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)",
- "rocket_contrib 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)",
- "rusoto_core 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_credential 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_mock 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_ses 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_sqs 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=d7f6d82fe4d35ee79c424dd4164733b22f17f80a)",
+ "rocket_codegen 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=d7f6d82fe4d35ee79c424dd4164733b22f17f80a)",
+ "rocket_contrib 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=d7f6d82fe4d35ee79c424dd4164733b22f17f80a)",
+ "rusoto_core 0.33.0 (git+https://github.com/rusoto/rusoto/?rev=9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9)",
+ "rusoto_credential 0.12.0 (git+https://github.com/rusoto/rusoto/?rev=9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9)",
+ "rusoto_mock 0.26.0 (git+https://github.com/rusoto/rusoto/?rev=9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9)",
+ "rusoto_ses 0.33.0 (git+https://github.com/rusoto/rusoto/?rev=9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9)",
+ "rusoto_sqs 0.33.0 (git+https://github.com/rusoto/rusoto/?rev=9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9)",
  "sendgrid 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -499,6 +543,23 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "h2"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "string 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -531,6 +592,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "winutil 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "http"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -583,6 +654,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper"
+version = "0.12.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "h2 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "httparse 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "itoa 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "net2 0.2.33 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-executor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-reactor 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tcp 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -593,6 +689,19 @@ dependencies = [
  "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-service 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "bytes 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "native-tls 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-tls 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -956,17 +1065,17 @@ dependencies = [
 [[package]]
 name = "pear"
 version = "0.1.0"
-source = "git+http://github.com/SergioBenitez/Pear?rev=54667ae#54667aefef084f2411e86392402a955770f1e7aa"
+source = "git+http://github.com/SergioBenitez/Pear?rev=b475140#b4751403ed9a06bc813b662334f0a555eccae6a0"
 dependencies = [
- "pear_codegen 0.1.0 (git+http://github.com/SergioBenitez/Pear?rev=54667ae)",
+ "pear_codegen 0.1.0 (git+http://github.com/SergioBenitez/Pear?rev=b475140)",
 ]
 
 [[package]]
 name = "pear_codegen"
 version = "0.1.0"
-source = "git+http://github.com/SergioBenitez/Pear?rev=54667ae#54667aefef084f2411e86392402a955770f1e7aa"
+source = "git+http://github.com/SergioBenitez/Pear?rev=b475140#b4751403ed9a06bc813b662334f0a555eccae6a0"
 dependencies = [
- "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1020,7 +1129,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.6"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1028,15 +1137,10 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "quote"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1206,16 +1310,16 @@ dependencies = [
 [[package]]
 name = "rocket"
 version = "0.4.0-dev"
-source = "git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643#18a91c938eb534a410a76137fbf114333ab38643"
+source = "git+https://github.com/SergioBenitez/Rocket?rev=d7f6d82fe4d35ee79c424dd4164733b22f17f80a#d7f6d82fe4d35ee79c424dd4164733b22f17f80a"
 dependencies = [
  "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "isatty 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "pear 0.1.0 (git+http://github.com/SergioBenitez/Pear?rev=54667ae)",
- "rocket_codegen_next 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)",
- "rocket_http 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)",
+ "pear 0.1.0 (git+http://github.com/SergioBenitez/Pear?rev=b475140)",
+ "rocket_codegen_next 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=d7f6d82fe4d35ee79c424dd4164733b22f17f80a)",
+ "rocket_http 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=d7f6d82fe4d35ee79c424dd4164733b22f17f80a)",
  "state 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1226,10 +1330,10 @@ dependencies = [
 [[package]]
 name = "rocket_codegen"
 version = "0.4.0-dev"
-source = "git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643#18a91c938eb534a410a76137fbf114333ab38643"
+source = "git+https://github.com/SergioBenitez/Rocket?rev=d7f6d82fe4d35ee79c424dd4164733b22f17f80a#d7f6d82fe4d35ee79c424dd4164733b22f17f80a"
 dependencies = [
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket_http 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)",
+ "rocket_http 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=d7f6d82fe4d35ee79c424dd4164733b22f17f80a)",
  "version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "yansi 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1237,20 +1341,20 @@ dependencies = [
 [[package]]
 name = "rocket_codegen_next"
 version = "0.4.0-dev"
-source = "git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643#18a91c938eb534a410a76137fbf114333ab38643"
+source = "git+https://github.com/SergioBenitez/Rocket?rev=d7f6d82fe4d35ee79c424dd4164733b22f17f80a#d7f6d82fe4d35ee79c424dd4164733b22f17f80a"
 dependencies = [
- "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "derive_utils 0.1.0 (git+https://github.com/SergioBenitez/derive-utils?rev=160da392)",
  "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rocket_http 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=d7f6d82fe4d35ee79c424dd4164733b22f17f80a)",
 ]
 
 [[package]]
 name = "rocket_contrib"
 version = "0.4.0-dev"
-source = "git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643#18a91c938eb534a410a76137fbf114333ab38643"
+source = "git+https://github.com/SergioBenitez/Rocket?rev=d7f6d82fe4d35ee79c424dd4164733b22f17f80a#d7f6d82fe4d35ee79c424dd4164733b22f17f80a"
 dependencies = [
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocket 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)",
+ "rocket 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=d7f6d82fe4d35ee79c424dd4164733b22f17f80a)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1258,86 +1362,86 @@ dependencies = [
 [[package]]
 name = "rocket_http"
 version = "0.4.0-dev"
-source = "git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643#18a91c938eb534a410a76137fbf114333ab38643"
+source = "git+https://github.com/SergioBenitez/Rocket?rev=d7f6d82fe4d35ee79c424dd4164733b22f17f80a#d7f6d82fe4d35ee79c424dd4164733b22f17f80a"
 dependencies = [
- "cookie 0.11.0-dev (git+https://github.com/alexcrichton/cookie-rs?rev=0365a18)",
+ "cookie 0.11.0-dev (git+https://github.com/alexcrichton/cookie-rs?rev=f191ca50)",
  "hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "pear 0.1.0 (git+http://github.com/SergioBenitez/Pear?rev=54667ae)",
+ "pear 0.1.0 (git+http://github.com/SergioBenitez/Pear?rev=b475140)",
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "state 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rusoto_core"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.33.0"
+source = "git+https://github.com/rusoto/rusoto/?rev=9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9#9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9"
 dependencies = [
  "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper-tls 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-tls 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_credential 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "md5 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_credential 0.12.0 (git+https://github.com/rusoto/rusoto/?rev=9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9)",
  "rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha2 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rusoto_credential"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.12.0"
+source = "git+https://github.com/rusoto/rusoto/?rev=9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9#9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9"
 dependencies = [
  "chrono 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "dirs 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper-tls 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-tls 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-timer 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rusoto_mock"
 version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/rusoto/rusoto/?rev=9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9#9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9"
 dependencies = [
  "chrono 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_core 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_core 0.33.0 (git+https://github.com/rusoto/rusoto/?rev=9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9)",
 ]
 
 [[package]]
 name = "rusoto_ses"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.33.0"
+source = "git+https://github.com/rusoto/rusoto/?rev=9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9#9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_core 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_core 0.33.0 (git+https://github.com/rusoto/rusoto/?rev=9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9)",
  "xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "rusoto_sqs"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.33.0"
+source = "git+https://github.com/rusoto/rusoto/?rev=9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9#9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9"
 dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
- "hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "rusoto_core 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rusoto_core 0.33.0 (git+https://github.com/rusoto/rusoto/?rev=9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9)",
  "xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1457,7 +1561,7 @@ name = "serde_derive"
 version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1589,8 +1693,8 @@ name = "socketlabs"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1603,40 +1707,29 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "syn"
-version = "0.11.11"
+name = "string"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "syn"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "synom"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "synstructure"
-version = "0.6.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1906,6 +1999,11 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "try-lock"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "typeable"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1947,11 +2045,6 @@ dependencies = [
 [[package]]
 name = "unicode-normalization"
 version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "unicode-xid"
-version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -2024,6 +2117,16 @@ dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "try-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "want"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2117,7 +2220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum config 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b5379dd8b3e7f488a31107d2c9586ce2ddbee2bc839201b3b38dbdf550351c1e"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
-"checksum cookie 0.11.0-dev (git+https://github.com/alexcrichton/cookie-rs?rev=0365a18)" = "<none>"
+"checksum cookie 0.11.0-dev (git+https://github.com/alexcrichton/cookie-rs?rev=f191ca50)" = "<none>"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"
 "checksum core-foundation-sys 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
 "checksum crc 1.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d663548de7f5cca343f1e0a48d14dcfb0e9eb4e079ec58883b7251539fa10aeb"
@@ -2127,7 +2230,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum crypto-mac 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0999b4ff4d3446d4ddb19a63e9e00c1876e75cd7000d20e57a693b4b3f08d958"
 "checksum crypto-mac 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7afa06d05a046c7a47c3a849907ec303504608c927f4e85f7bfff22b7180d971"
 "checksum data-encoding 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "67df0571a74bf0d97fb8b2ed22abdd9a48475c96bd327db968b7d9cace99655e"
+"checksum derive_utils 0.1.0 (git+https://github.com/SergioBenitez/derive-utils?rev=160da392)" = "<none>"
+"checksum derive_utils_codegen 0.1.0 (git+https://github.com/SergioBenitez/derive-utils?rev=160da392)" = "<none>"
+"checksum derive_utils_core 0.1.0 (git+https://github.com/SergioBenitez/derive-utils?rev=160da392)" = "<none>"
 "checksum digest 0.7.5 (registry+https://github.com/rust-lang/crates.io-index)" = "5b29c278aa8fd30796bd977169e8004b4aa88cdcd2f32a6eb22bc2d5d38df94a"
+"checksum dirs 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "37a76dd8b997af7107d0bb69d43903cf37153a18266f8b3fdb9911f28efb5444"
 "checksum dtoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "6d301140eb411af13d3115f9a562c85cc6b541ade9dfa314132244aaee7489dd"
 "checksum email 0.0.19 (registry+https://github.com/rust-lang/crates.io-index)" = "faacb54ba5ccc18b63f197548756b92e25a3a311696e84044238baf39b90c74a"
 "checksum emailaddress 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9a621dc14b6dc6f847ef83ee630672d4b46c2d6df96d2e108b27343329684a44"
@@ -2142,9 +2249,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum encoding_rs 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "98fd0f24d1fb71a4a6b9330c8ca04cbd4e7cc5d846b54ca74ff376bc7c9f798d"
 "checksum erased-serde 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c564e32677839f1c551664c478e079c9b128a1a2d223180bffb2ddfabeded0be"
 "checksum error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff511d5dc435d703f4971bc399647c9bc38e20cb41452e3b9feb4765419ed3f3"
-"checksum failure 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "934799b6c1de475a012a02dab0ace1ace43789ee4b99bcfbf1a2e3e8ced5de82"
-"checksum failure_derive 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "c7cdda555bb90c9bb67a3b670a0f42de8e73f5981524123ad8578aafec8ddb8b"
+"checksum failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7efb22686e4a466b1ec1a15c2898f91fa9cb340452496dca654032de20ff95b9"
+"checksum failure_derive 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "946d0e98a50d9831f5d589038d2ca7f8f455b1c21028c0db0e84116a12696426"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
+"checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
@@ -2152,14 +2260,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)" = "884dbe32a6ae4cd7da5c6db9b78114449df9953b8d490c9d7e1b51720b922c62"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
+"checksum h2 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "35754349586639c6ff629abd19a605e5a42599b0da4aff7be67d63e48ef1ba4e"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum hmac 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "44f3bdb08579d99d7dc761c0e266f13b5f2ab8c8c703b9fc9ef333cd8f48f55e"
 "checksum hmac 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "efb895368093a17d136b1d9eecdb607c7aa038a452e646c74e37ded2da106285"
 "checksum hostname 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "21ceb46a83a85e824ef93669c8b390009623863b5c195d1ba747292c0c72f94e"
+"checksum http 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "a14e554a88fc4180b192e91fda0de4c1f00d5c57d7d0afdacade279464a548de"
 "checksum httparse 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7b6288d7db100340ca12873fd4d08ad1b8f206a9457798dfb17c018a33fee540"
 "checksum hyper 0.10.13 (registry+https://github.com/rust-lang/crates.io-index)" = "368cb56b2740ebf4230520e2b90ebb0461e69034d85d1945febd9b3971426db2"
 "checksum hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)" = "34a590ca09d341e94cddf8e5af0bbccde205d5fbc2fa3c09dd67c7f85cea59d7"
+"checksum hyper 0.12.7 (registry+https://github.com/rust-lang/crates.io-index)" = "c087746de95e20e4dabe86606c3a019964a8fde2d5f386152939063c116c5971"
 "checksum hyper-tls 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a5aa51f6ae9842239b0fac14af5f22123b8432b4cc774a44ff059fcba0f675ca"
+"checksum hyper-tls 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d5787cee312507c4d005405e75da2b3357b58c47e3f14cddfa5f05c98edf6f29"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum indexmap 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "08173ba1e906efb6538785a8844dd496f5d34f0a2d88038e95195172fc667220"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
@@ -2202,16 +2314,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum num_cpus 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c51a3322e4bca9d212ad9a158a02abc6934d005490c054a2778df73a70aa0a30"
 "checksum openssl 0.9.24 (registry+https://github.com/rust-lang/crates.io-index)" = "a3605c298474a3aa69de92d21139fb5e2a81688d308262359d85cdd0d12a7985"
 "checksum openssl-sys 0.9.33 (registry+https://github.com/rust-lang/crates.io-index)" = "d8abc04833dcedef24221a91852931df2f63e3369ae003134e70aff3645775cc"
-"checksum pear 0.1.0 (git+http://github.com/SergioBenitez/Pear?rev=54667ae)" = "<none>"
-"checksum pear_codegen 0.1.0 (git+http://github.com/SergioBenitez/Pear?rev=54667ae)" = "<none>"
+"checksum pear 0.1.0 (git+http://github.com/SergioBenitez/Pear?rev=b475140)" = "<none>"
+"checksum pear_codegen 0.1.0 (git+http://github.com/SergioBenitez/Pear?rev=b475140)" = "<none>"
 "checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum phf 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)" = "7d37a244c75a9748e049225155f56dbcb98fe71b192fd25fd23cb914b5ad62f2"
 "checksum phf_codegen 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)" = "4e4048fe7dd7a06b8127ecd6d3803149126e9b33c7558879846da3a63f734f2b"
 "checksum phf_generator 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)" = "05a079dd052e7b674d21cb31cbb6c05efd56a2cd2827db7692e2f1a507ebd998"
 "checksum phf_shared 0.7.22 (registry+https://github.com/rust-lang/crates.io-index)" = "c2261d544c2bb6aa3b10022b0be371b9c7c64f762ef28c6f5d4f1ef6d97b5930"
 "checksum pkg-config 0.3.11 (registry+https://github.com/rust-lang/crates.io-index)" = "110d5ee3593dbb73f56294327fe5668bcc997897097cbc76b51e7aed3f52452f"
-"checksum proc-macro2 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "effdb53b25cdad54f8f48843d67398f7ef2e14f12c1b4cb4effc549a6462a4d6"
-"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+"checksum proc-macro2 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "cccdc7557a98fe98453030f077df7f3a042052fae465bb61d2c2c41435cfd9b6"
 "checksum quote 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "e44651a0dc4cdd99f71c83b561e221f714912d11af1a4dff0631f923d53af035"
 "checksum quoted_printable 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4126fa98c6d7b166e6a29a24ab96721d618759d803df6a8cb35d6140da475b5a"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
@@ -2230,16 +2341,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum remove_dir_all 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3488ba1b9a2084d38645c4c08276a1752dcbf2c7130d74f1569681ad5d2799c5"
 "checksum reqwest 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2abe46f8e00792693a2488e296c593d1f4ea39bb1178cfce081d6793657575e4"
 "checksum ring 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe642b9dd1ba0038d78c4a3999d1ee56178b4d415c1e1fbaba83b06dce012f0"
-"checksum rocket 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)" = "<none>"
-"checksum rocket_codegen 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)" = "<none>"
-"checksum rocket_codegen_next 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)" = "<none>"
-"checksum rocket_contrib 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)" = "<none>"
-"checksum rocket_http 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=18a91c938eb534a410a76137fbf114333ab38643)" = "<none>"
-"checksum rusoto_core 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "12daaa6d62d64f6447bf0299ce775f4e05f8e75e5418e817da094b9de04ad22d"
-"checksum rusoto_credential 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "53199d09fd1b7d4f5ac50f4d23106577624238ea77cae2b44eb1d1fc4cd956a4"
-"checksum rusoto_mock 0.26.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4eecb9cf02c12eb9276f61589aa2d47ab06d9aa6fa04b2dfdc8a39b6786c8289"
-"checksum rusoto_ses 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "88d4645c94b099369602db7d814b1741f991b3d6821d8076b2ac67824b8cc130"
-"checksum rusoto_sqs 0.32.0 (registry+https://github.com/rust-lang/crates.io-index)" = "995322c1530460a18fadd2f16761f22ba3f4e1fe630e344ca97e81d921abfb00"
+"checksum rocket 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=d7f6d82fe4d35ee79c424dd4164733b22f17f80a)" = "<none>"
+"checksum rocket_codegen 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=d7f6d82fe4d35ee79c424dd4164733b22f17f80a)" = "<none>"
+"checksum rocket_codegen_next 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=d7f6d82fe4d35ee79c424dd4164733b22f17f80a)" = "<none>"
+"checksum rocket_contrib 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=d7f6d82fe4d35ee79c424dd4164733b22f17f80a)" = "<none>"
+"checksum rocket_http 0.4.0-dev (git+https://github.com/SergioBenitez/Rocket?rev=d7f6d82fe4d35ee79c424dd4164733b22f17f80a)" = "<none>"
+"checksum rusoto_core 0.33.0 (git+https://github.com/rusoto/rusoto/?rev=9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9)" = "<none>"
+"checksum rusoto_credential 0.12.0 (git+https://github.com/rusoto/rusoto/?rev=9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9)" = "<none>"
+"checksum rusoto_mock 0.26.0 (git+https://github.com/rusoto/rusoto/?rev=9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9)" = "<none>"
+"checksum rusoto_ses 0.33.0 (git+https://github.com/rusoto/rusoto/?rev=9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9)" = "<none>"
+"checksum rusoto_sqs 0.33.0 (git+https://github.com/rusoto/rusoto/?rev=9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9)" = "<none>"
 "checksum rust-ini 0.12.2 (registry+https://github.com/rust-lang/crates.io-index)" = "ac66e816614e124a692b6ac1b8437237a518c9155a3aacab83a373982630c715"
 "checksum rustc-demangle 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "76d7ba1feafada44f2d38eed812bd2489a03c0f5abb975799251518b68848649"
 "checksum rustc_version 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a54aa04a10c68c1c4eacb4337fd883b435997ede17a9385784b990777686b09a"
@@ -2273,10 +2384,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum smallvec 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "26df3bb03ca5eac2e64192b723d51f56c1b1e0860e7c766281f4598f181acdc8"
 "checksum socketlabs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "39ffaf38bb6789b4633ec7185534666e34798cab87754aa19a36f297f0aca516"
 "checksum state 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7345c971d1ef21ffdbd103a75990a15eb03604fc8b8852ca8cb418ee1a099028"
-"checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+"checksum string 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00caf261d6f90f588f8450b8e1230fa0d5be49ee6140fdfbcb55335aff350970"
 "checksum syn 0.14.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2beff8ebc3658f07512a413866875adddd20f4fd47b2a4e6c9da65cd281baaea"
-"checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-"checksum synstructure 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3a761d12e6d8dcb4dcf952a7a89b475e3a9d69e4a69307e01a470977642914bd"
+"checksum synstructure 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "85bb9b7550d063ea184027c9b8c20ac167cd36d3e06b3a40bceb9d746dc1a7b7"
 "checksum take 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b157868d8ac1f56b64604539990685fa7611d8fa9e5476cf0c02cf34d32917c5"
 "checksum take_mut 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
@@ -2303,6 +2413,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum toml 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "a0263c6c02c4db6c8f7681f9fd35e90de799ebd4cfdeab77a38f4ff6b3d8c0d9"
 "checksum traitobject 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efd1f82c56340fdf16f2a953d7bda4f8fdffba13d93b00844c25572110b26079"
 "checksum try-lock 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee2aa4715743892880f70885373966c83d73ef1b0838a664ef0c76fffd35e7c2"
+"checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 "checksum typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1410f6f91f21d1612654e7cc69193b0334f909dcf2c790c4826254fbb86f8887"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
@@ -2310,7 +2421,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum unicase 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "284b6d3db520d67fbe88fd778c21510d1b0ba4a551e5d0fbb023d33405f6de8a"
 "checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "6a0180bc61fc5a987082bfa111f4cc95c4caff7f9799f3e46df09163a937aa25"
-"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
 "checksum untrusted 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "55cd1f4b4e96b46aeb8d4855db4a7a9bd96eeeb5c6a1ab54593328761642ce2f"
@@ -2322,6 +2432,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum version_check 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7716c242968ee87e5542f8021178248f267f295a5c4803beae8b8b7fd9bc6051"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum want 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "a05d9d966753fa4b5c8db73fcab5eed4549cfe0e1e4e66911e5564a0085c35d1"
+"checksum want 0.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "797464475f30ddb8830cc529aaaae648d581f99e2036a928877dfde027ddf6b3"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ base64 = ">=0.6.0"
 chrono = { version = ">=0.4.2", features = [ "serde" ] }
 config = ">=0.8.0"
 emailmessage = ">=0.1.0"
-failure = ">=0.1.1"
+failure = ">=0.1.2"
 futures = ">=0.1.21,<0.2"
 hex = ">=0.3.2"
 hmac = ">=0.6.2"
@@ -30,14 +30,14 @@ redis = ">=0.8.0"
 regex = ">=1.0"
 reqwest = ">=0.8.5"
 # Remove once a new version of rocket containing this commit is released.
-rocket = { git = "https://github.com/SergioBenitez/Rocket", rev="18a91c938eb534a410a76137fbf114333ab38643" }
-rocket_codegen = { git = "https://github.com/SergioBenitez/Rocket", rev="18a91c938eb534a410a76137fbf114333ab38643" }
-rocket_contrib = { git = "https://github.com/SergioBenitez/Rocket", rev="18a91c938eb534a410a76137fbf114333ab38643" }
-rusoto_core = ">=0.32.0"
-rusoto_credential = ">=0.11.0"
-rusoto_mock = ">=0.26.0"
-rusoto_ses = ">=0.32.0"
-rusoto_sqs = ">=0.32.0"
+rocket = { git = "https://github.com/SergioBenitez/Rocket", rev="d7f6d82fe4d35ee79c424dd4164733b22f17f80a" }
+rocket_codegen = { git = "https://github.com/SergioBenitez/Rocket", rev="d7f6d82fe4d35ee79c424dd4164733b22f17f80a" }
+rocket_contrib = { git = "https://github.com/SergioBenitez/Rocket", rev="d7f6d82fe4d35ee79c424dd4164733b22f17f80a" }
+rusoto_core = { git = "https://github.com/rusoto/rusoto/", rev="9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9" }
+rusoto_credential = { git = "https://github.com/rusoto/rusoto/", rev="9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9" }
+rusoto_mock = { git = "https://github.com/rusoto/rusoto/", rev="9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9" }
+rusoto_ses = { git = "https://github.com/rusoto/rusoto/", rev="9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9" }
+rusoto_sqs = { git = "https://github.com/rusoto/rusoto/", rev="9e22eb3876a02375b3dbe14d0340f9b5c1fc55e9" }
 sendgrid = ">=0.7.1"
 serde = ">=1.0"
 serde_derive = ">=1.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM rust:1.26.0-stretch as builder
 ADD . /app
 WORKDIR /app
 # Make sure that this matches in .travis.yml
-ARG RUST_TOOLCHAIN=nightly-2018-07-14
+ARG RUST_TOOLCHAIN=nightly-2018-08-06
 RUN \
     apt-get -qq update && \
     apt-get -qq install -y default-libmysqlclient-dev && \

--- a/src/auth_db/mod.rs
+++ b/src/auth_db/mod.rs
@@ -255,8 +255,7 @@ impl Db for DbClient {
                 bounce_type,
                 bounce_subtype,
                 created_at: 0,
-            })
-            .send()?;
+            }).send()?;
         match response.status() {
             StatusCode::Ok => Ok(()),
             status => Err(AppErrorKind::DbError(format!("{}", status)).into()),

--- a/src/auth_db/test.rs
+++ b/src/auth_db/test.rs
@@ -160,13 +160,13 @@ fn create_bounce() {
     let email_addresses = vec![generate_email_address("foo"), generate_email_address("bar")];
 
     let bounces_before = db.get_bounces(&email_addresses[0]).expect("db error");
-    let bounces_after =
-        db.create_bounce(
+    let bounces_after = db
+        .create_bounce(
             &email_addresses[0],
             BounceType::Hard,
             BounceSubtype::General,
         ).and_then(|_| db.get_bounces(&email_addresses[0]))
-            .expect("db error");
+        .expect("db error");
     let now = now_as_milliseconds();
 
     // The next assertion is conditional because fxa-auth-db-mysql limits
@@ -183,13 +183,13 @@ fn create_bounce() {
     assert_eq!(bounce.bounce_subtype, BounceSubtype::General);
     assert!(bounce.created_at > now - 1000);
 
-    let bounces_after =
-        db.create_bounce(
+    let bounces_after = db
+        .create_bounce(
             &email_addresses[1],
             BounceType::Soft,
             BounceSubtype::MailboxFull,
         ).and_then(|_| db.get_bounces(&email_addresses[1]))
-            .expect("db error");
+        .expect("db error");
     let now = now_as_milliseconds();
 
     let second_bounce = &bounces_after[0];

--- a/src/bin/queues.rs
+++ b/src/bin/queues.rs
@@ -48,8 +48,7 @@ fn main() {
             .or_else(|error: QueueError| {
                 println!("{:?}", error);
                 future::ok(0)
-            })
-            .and_then(move |count: usize| {
+            }).and_then(move |count: usize| {
                 let total_count = count + previous_count;
                 println!(
                     "Processed {} messages, total message count is now {}",

--- a/src/bounces/mod.rs
+++ b/src/bounces/mod.rs
@@ -85,8 +85,7 @@ where
                 }
 
                 Ok(counts)
-            })
-            .map(|_| ())
+            }).map(|_| ())
     }
 
     /// Record a hard or soft bounce

--- a/src/bounces/test.rs
+++ b/src/bounces/test.rs
@@ -456,8 +456,7 @@ fn record_bounce() {
             &address,
             BounceType::Transient,
             BounceSubtype::AttachmentRejected,
-        )
-        .unwrap();
+        ).unwrap();
     let db = DbClient::new(&settings);
     let bounce_records = db.get_bounces(&address).unwrap();
     let now = now_as_milliseconds();

--- a/src/message_data/mod.rs
+++ b/src/message_data/mod.rs
@@ -57,8 +57,7 @@ impl MessageData {
             .map(|metadata| {
                 self.client.del::<&str, u8>(key_str).ok();
                 metadata
-            })
-            .map_err(From::from)
+            }).map_err(From::from)
     }
 
     /// Store message metadata.

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -62,8 +62,7 @@ fn build_multipart_mime(
         SinglePart::quoted_printable()
             .with_header(header::ContentType(
                 "text/plain; charset=utf8".parse().unwrap(),
-            ))
-            .with_body(body_text.to_owned()),
+            )).with_body(body_text.to_owned()),
     );
     if let Some(body_html) = body_html {
         body = body.with_multipart(
@@ -71,8 +70,7 @@ fn build_multipart_mime(
                 SinglePart::eight_bit()
                     .with_header(header::ContentType(
                         "text/html; charset=utf8".parse().unwrap(),
-                    ))
-                    .with_body(body_html.to_owned()),
+                    )).with_body(body_html.to_owned()),
             ),
         )
     }

--- a/src/providers/sendgrid.rs
+++ b/src/providers/sendgrid.rs
@@ -90,8 +90,7 @@ impl Provider for SendgridProvider {
                                     "Missing or duplicate X-Message-Id header in Sendgrid response",
                                 ),
                             }.into(),
-                        )
-                        .and_then(|message_id| from_utf8(message_id).map_err(From::from))
+                        ).and_then(|message_id| from_utf8(message_id).map_err(From::from))
                         .map(|message_id| message_id.to_string())
                 } else {
                     Err(AppErrorKind::ProviderError {

--- a/src/providers/ses/test.rs
+++ b/src/providers/ses/test.rs
@@ -24,7 +24,7 @@ fn ses_send_handles_ok_response() {
     "#;
     let mock_dispatcher = MockRequestDispatcher::with_status(200).with_body(&body);
     let mock_ses = SesProvider {
-        client: Box::new(SesClient::new(
+        client: Box::new(SesClient::new_with(
             mock_dispatcher,
             MockCredentialsProvider,
             Region::SaEast1,
@@ -51,7 +51,7 @@ fn ses_send_handles_unicode_characters() {
     "#;
     let mock_dispatcher = MockRequestDispatcher::with_status(200).with_body(&body);
     let mock_ses = SesProvider {
-        client: Box::new(SesClient::new(
+        client: Box::new(SesClient::new_with(
             mock_dispatcher,
             MockCredentialsProvider,
             Region::SaEast1,
@@ -76,7 +76,7 @@ fn ses_send_handles_error_response() {
     let body = "FREAKOUT";
     let mock_dispatcher = MockRequestDispatcher::with_status(500).with_body(&body);
     let mock_ses = SesProvider {
-        client: Box::new(SesClient::new(
+        client: Box::new(SesClient::new_with(
             mock_dispatcher,
             MockCredentialsProvider,
             Region::SaEast1,

--- a/src/providers/socketlabs.rs
+++ b/src/providers/socketlabs.rs
@@ -57,17 +57,17 @@ impl Provider for SocketLabsProvider {
             self.settings.key.clone(),
             vec![message],
         )?.send()
-            .map_err(From::from)
-            .and_then(|response| {
-                if response.error_code == PostMessageErrorCode::Success {
-                    Ok("".to_string())
-                } else {
-                    Err(AppErrorKind::ProviderError {
-                        name: String::from("SocketLabs"),
-                        description: format!("{:?}: {}", response.error_code, response.error_code),
-                    }.into())
-                }
-            })
+        .map_err(From::from)
+        .and_then(|response| {
+            if response.error_code == PostMessageErrorCode::Success {
+                Ok("".to_string())
+            } else {
+                Err(AppErrorKind::ProviderError {
+                    name: String::from("SocketLabs"),
+                    description: format!("{:?}: {}", response.error_code, response.error_code),
+                }.into())
+            }
+        })
     }
 }
 

--- a/src/queues/mod.rs
+++ b/src/queues/mod.rs
@@ -105,8 +105,7 @@ impl Queues {
             .join3(
                 self.process_queue(&self.complaint_queue),
                 self.process_queue(&self.delivery_queue),
-            )
-            .map(|results| results.0 + results.1 + results.2);
+            ).map(|results| results.0 + results.1 + results.2);
 
         Box::new(joined_futures)
     }
@@ -125,8 +124,7 @@ impl Queues {
                     }
                 }
                 future::join_all(futures.into_iter())
-            })
-            .map(|results| results.len());
+            }).map(|results| results.len());
         Box::new(future)
     }
 
@@ -154,8 +152,7 @@ impl Queues {
                     .map(|id| {
                         println!("Sent message to notification queue, id=`{}`", id);
                         ()
-                    })
-                    .or_else(|error| {
+                    }).or_else(|error| {
                         // Errors sending to this queue are non-fatal because it's only used
                         // for logging. We still want to delete the message from the queue.
                         println!("{:?}", error);
@@ -170,8 +167,11 @@ impl Queues {
     fn record_bounce(&'static self, notification: &Notification) -> DbResult {
         if let Some(ref bounce) = notification.bounce {
             for recipient in &bounce.bounced_recipients {
-                self.bounces
-                    .record_bounce(&recipient, bounce.bounce_type, bounce.bounce_subtype)?;
+                self.bounces.record_bounce(
+                    &recipient,
+                    bounce.bounce_type,
+                    bounce.bounce_subtype,
+                )?;
             }
             Ok(())
         } else {

--- a/src/send/mod.rs
+++ b/src/send/mod.rs
@@ -113,14 +113,12 @@ fn handler(
             email.body.text.as_ref(),
             email.body.html.as_ref().map(|html| html.as_ref()),
             email.provider.as_ref().map(|provider| provider.as_ref()),
-        )
-        .map(|message_id| {
+        ).map(|message_id| {
             email
                 .metadata
                 .as_ref()
                 .and_then(|metadata| message_data.set(message_id.as_str(), metadata).err())
                 .map(|error| println!("{}", error));
             Json(json!({ "messageId": message_id }))
-        })
-        .map_err(|error| error)
+        }).map_err(|error| error)
 }

--- a/src/send/test.rs
+++ b/src/send/test.rs
@@ -61,8 +61,7 @@ fn single_recipient() {
       },
       "provider": "mock"
     }"#,
-        )
-        .dispatch();
+        ).dispatch();
 
     assert_eq!(response.status(), Status::Ok);
 
@@ -88,8 +87,7 @@ fn multiple_recipients() {
       },
       "provider": "mock"
     }"#,
-        )
-        .dispatch();
+        ).dispatch();
 
     assert_eq!(response.status(), Status::Ok);
 
@@ -113,8 +111,7 @@ fn without_optional_data() {
       },
       "provider": "mock"
     }"#,
-        )
-        .dispatch();
+        ).dispatch();
 
     assert_eq!(response.status(), Status::Ok);
 
@@ -138,8 +135,7 @@ fn unicode_email_field() {
       },
       "provider": "mock"
     }"#,
-        )
-        .dispatch();
+        ).dispatch();
 
     assert_eq!(response.status(), Status::Ok);
 
@@ -164,8 +160,7 @@ fn unicode_message_body() {
       },
       "provider": "mock"
     }"#,
-        )
-        .dispatch();
+        ).dispatch();
 
     assert_eq!(response.status(), Status::Ok);
 
@@ -189,8 +184,7 @@ fn unicode_message_subject() {
       },
       "provider": "mock"
     }"#,
-        )
-        .dispatch();
+        ).dispatch();
 
     assert_eq!(response.status(), Status::Ok);
 
@@ -213,8 +207,7 @@ fn missing_to_field() {
       },
       "provider": "mock"
     }"#,
-        )
-        .dispatch();
+        ).dispatch();
 
     assert_eq!(response.status(), Status::BadRequest);
 
@@ -238,8 +231,7 @@ fn missing_subject_field() {
       },
       "provider": "mock"
     }"#,
-        )
-        .dispatch();
+        ).dispatch();
 
     assert_eq!(response.status(), Status::BadRequest);
 
@@ -264,8 +256,7 @@ fn missing_body_text_field() {
       },
       "provider": "mock"
     }"#,
-        )
-        .dispatch();
+        ).dispatch();
 
     assert_eq!(response.status(), Status::BadRequest);
 
@@ -290,8 +281,7 @@ fn invalid_to_field() {
       },
       "provider": "mock"
     }"#,
-        )
-        .dispatch();
+        ).dispatch();
 
     assert_eq!(response.status(), Status::BadRequest);
 
@@ -317,8 +307,7 @@ fn invalid_cc_field() {
       },
       "provider": "mock"
     }"#,
-        )
-        .dispatch();
+        ).dispatch();
 
     assert_eq!(response.status(), Status::BadRequest);
 


### PR DESCRIPTION
Fixes #156 
Fixes #158 

Here I update failure, rocket, rusoto and rust to the latest versions.

I had to point rusoto to a revision, because `rusoto_mock` stopped working after the update. I opened an issue about that https://github.com/rusoto/rusoto/issues/1089.

Because I updated the rust version, there are a bunch of formatting changes in this PR, because fmt was updated as well.

r? @philbooth @vladikoff 

_ps.: when this gets merged we can't forget to change the override in `fxa-local-dev` https://github.com/mozilla/fxa-local-dev/blob/master/_scripts/install_all.sh#L42_