### PR TITLE
feat(socketlabs): create and return id for socketlabs messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -563,6 +563,7 @@ dependencies = [
  "slog-scope 4.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "slog-term 2.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "socketlabs 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,4 @@ slog-mozlog-json = ">=0.1.0"
 slog-scope = ">=4.0.1"
 slog-term = ">=2.4.0"
 socketlabs = ">=0.1.3"
+uuid = { version = ">=0.6", features = ["v4"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ extern crate slog_mozlog_json;
 extern crate slog_scope;
 extern crate slog_term;
 extern crate socketlabs;
+extern crate uuid;
 
 pub mod app_errors;
 pub mod auth_db;

--- a/src/providers/socketlabs.rs
+++ b/src/providers/socketlabs.rs
@@ -6,6 +6,7 @@ use socketlabs::{
     error::Error as SocketLabsError, message::Message, request::Request,
     response::PostMessageErrorCode,
 };
+use uuid::Uuid;
 
 use super::{Headers, Provider};
 use app_errors::{AppError, AppErrorKind, AppResult};
@@ -51,6 +52,8 @@ impl Provider for SocketLabsProvider {
         if let Some(html) = body_html {
             message.set_html(html);
         }
+        let message_id = Uuid::new_v4().to_string();
+        message.set_message_id(message_id.clone());
 
         Request::new(
             self.settings.serverid,
@@ -60,7 +63,7 @@ impl Provider for SocketLabsProvider {
         .map_err(From::from)
         .and_then(|response| {
             if response.error_code == PostMessageErrorCode::Success {
-                Ok("".to_string())
+                Ok(message_id)
             } else {
                 Err(AppErrorKind::ProviderError {
                     name: String::from("SocketLabs"),


### PR DESCRIPTION
Turns out we can manually add a message id to socketlabs requests.

See more discussion in https://github.com/mozilla/fxa-sendgrid-event-proxy/pull/3#discussion_r209323789

r? @philbooth @vladikoff 