### PR TITLE
fix(logging): remove unnecessary and add debug logs in queues

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,6 +67,7 @@ extern crate serde_test;
 extern crate sha2;
 #[macro_use(
     slog_b,
+    slog_debug,
     slog_error,
     slog_info,
     slog_kv,


### PR DESCRIPTION
Fixes #173

There is a bunch of minor fixes going on in this PR.

- Fix #173 
- Add some debug logs for notifications in case we need it (probably would be good to only show them when we have some `debug` flag on or something)
- Notification JSON may come in different shapes, nested or not nested, so I added functionality to accept both. That logic might me a little fragile so let me know what you think.

r? @vladikoff @philbooth 