### PR TITLE
fix(queues): make queue parsing logic follow the sns format

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,6 @@ extern crate serde_test;
 extern crate sha2;
 #[macro_use(
     slog_b,
-    slog_debug,
     slog_error,
     slog_info,
     slog_kv,

--- a/src/queues/sqs/mod.rs
+++ b/src/queues/sqs/mod.rs
@@ -67,37 +67,33 @@ impl Queue {
             }.into());
         }
 
-        // The notification might come nested inside
-        // the `Message` property of a JSON or not.
-        let body_value = serde_json::from_str::<JsonValue>(&body)?;
-        // If the body has a "Message" property, it
-        // means the notification is nested inside it.
-        let notification = if let Some(notification) = body_value["Message"].as_str() {
-            notification
+        if let Some(ref message) = serde_json::from_str::<JsonValue>(&body)?["Message"].as_str() {
+            serde_json::from_str(message)
+                .map(|notification: SqsNotification| {
+                    info!(
+                        "Successfully parsed SQS message";
+                        "queue" => &self.url.clone(), 
+                        "receipt_handle" => &receipt_handle, 
+                        "notification_type" => &format!("{}", notification.notification_type)
+                    );
+                    Message {
+                        notification: From::from(notification),
+                        id: receipt_handle,
+                    }
+                }).map_err(|error| {
+                    AppErrorKind::SqsMessageParsingError {
+                        message: format!("{:?}", error),
+                        queue: self.url.clone(),
+                        body: format!("{}", body),
+                    }.into()
+                })
         } else {
-            &body
-        };
-
-        serde_json::from_str(notification)
-            .map(|notification: SqsNotification| {
-                debug!("{:?}", notification);
-                info!(
-                    "Successfully parsed SQS message";
-                    "queue" => &self.url.clone(), 
-                    "receipt_handle" => &receipt_handle, 
-                    "notification_type" => &format!("{}", notification.notification_type)
-                );
-                Message {
-                    notification: From::from(notification),
-                    id: receipt_handle,
-                }
-            }).map_err(|error| {
-                AppErrorKind::SqsMessageParsingError {
-                    message: format!("{:?}", error),
-                    queue: self.url.clone(),
-                    body: format!("{}", body),
-                }.into()
-            })
+            Err(AppErrorKind::SqsMessageParsingError {
+                message: format!("{}", "Unexpected SQS message structure"),
+                queue: self.url.clone(),
+                body: format!("{}", body),
+            }.into())
+        }
     }
 }
 


### PR DESCRIPTION
This is just a follow up PR from #177 

I remove the part where I make the parser work for different SNS message formats, turns out that is not needed. 

See discussion: https://github.com/mozilla/fxa-email-service/pull/177#issuecomment-414394797

r? @vladikoff 