### PR TITLE
chore(tests): add tests for message parsing in the queues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/bin/queues.rs"
 [dependencies]
 base64 = ">=0.6.0"
 chrono = { version = ">=0.4.2", features = [ "serde" ] }
-config = ">=0.8.0"
+config = ">=0.9.0"
 emailmessage = ">=0.1.0"
 failure = ">=0.1.2"
 futures = ">=0.1.21,<0.2"

--- a/src/queues/sqs/notification/test_notifications.json
+++ b/src/queues/sqs/notification/test_notifications.json
@@ -1,0 +1,119 @@
+[{
+    "notificationType": "Bounce",
+    "mail": {
+        "timestamp":"2016-01-27T14:05:45 +0000",
+        "messageId":"001",
+        "source":"foo@example.com",
+        "sourceArn": "arn:aws:ses:us-west-2:888888888888:identity/example.com",
+        "sourceIp": "127.0.1.0",
+        "sendingAccountId":"1234",
+        "destination":[
+            "bar@example.com"
+        ],
+        "headersTruncated":false,
+        "headers":[ 
+            { 
+                "name":"From",
+                "value":"\"Foo\" <foo@example.com>"
+            }
+        ],
+        "commonHeaders":{
+            "subject":"Bounce Subject"
+        }
+    },
+    "bounce": {
+        "bounceType":"Permanent",
+        "bounceSubType": "General",
+        "bouncedRecipients":[
+            {
+                "status":"5.0.0",
+                "action":"failed",
+                "diagnosticCode":"smtp; 550 user unknown",
+                "emailAddress":"bar@example.com"
+            },
+            {
+                "status":"5.0.0",
+                "action":"failed",
+                "diagnosticCode":"smtp; 550 user unknown",
+                "emailAddress":"baz@example.com"
+            },
+            {
+                "status":"5.0.0",
+                "action":"failed",
+                "diagnosticCode":"smtp; 550 user unknown",
+                "emailAddress":"qux@example.com"
+            }
+        ],
+        "reportingMTA": "example.com",
+        "timestamp":"2012-05-25T14:59:38.605Z",
+        "feedbackId":"000001378603176d-5a4b5ad9-6f30-4198-a8c3-b1eb0c270a1d-000000",
+        "remoteMtaIp":"127.0.2.0"
+    }
+},
+{
+    "notificationType": "Complaint",
+    "mail": {
+        "timestamp":"2018-02-14T09:15:51 +0000",
+        "messageId":"002",
+        "source":"qux@example.com",
+        "sourceArn": "arn:aws:ses:us-west-2:888888888888:identity/example.com",
+        "sourceIp": "127.0.2.0",
+        "sendingAccountId":"2345",
+        "destination":[
+            "baz@example.com"
+        ],
+        "headersTruncated":false,
+        "headers":[ 
+            { 
+                "name":"From",
+                "value":"\"Qux\" <qux@example.com>"
+            }
+        ],
+        "commonHeaders":{
+            "subject":"Complaint Subject"
+        }
+    },
+    "complaint": {
+        "userAgent":"AnyCompany Feedback Loop (V0.01)",
+        "complainedRecipients":[
+            {
+                "emailAddress":"baz@example.com"
+            }
+        ],
+        "complaintFeedbackType":"abuse",
+        "arrivalDate":"2009-12-03T04:24:21.000-05:00",
+        "timestamp":"2012-05-25T14:59:38.623Z",
+        "feedbackId":"000001378603177f-18c07c78-fa81-4a58-9dd1-fedc3cb8f49a-000000"
+    }
+},
+{
+    "notificationType": "Delivery",
+    "mail": {
+        "timestamp":"2017-04-24T15:44:00 +0000",
+        "messageId":"003",
+        "source":"quuz@example.com",
+        "sourceArn": "arn:aws:ses:us-west-2:888888888888:identity/example.com",
+        "sourceIp": "127.0.3.0",
+        "sendingAccountId":"3456",
+        "destination":[
+            "xyzzy@example.com"
+        ],
+        "headersTruncated":false,
+        "headers":[ 
+            { 
+                "name":"From",
+                "value":"\"Quuz\" <quuz@example.com>"
+            }],
+        "commonHeaders":{
+            "subject":"Delivery Subject"
+        }
+    },
+    "delivery": {
+        "timestamp":"2014-05-28T22:41:01.184Z",
+        "processingTimeMillis":546,
+        "recipients":["xyzzy@example.com"],
+        "smtpResponse":"250 ok:  Message 64111812 accepted",
+        "reportingMTA":"a8-70.smtp-out.amazonses.com",
+        "remoteMtaIp":"127.0.2.0"
+    }
+}]


### PR DESCRIPTION
Connects to #162 

I started working on this issue, but I'm not really sure I'm doing the right thing. I'm submitting this work in progress so that you can check that this is the kind of tests needed, @philbooth . I started the code for the tests, but before finishing it I just wanted to check, because it looks kind of weird to me...

I also added a commit that updates the config.rs version in the Cargo.toml because we had `0.8.0` there, but turns out we use features from the crate that don't exist in that version only on `>=0.9.0`. That was a problem I stumbled on while working on #162 this is why the commit is in this PR. It was such a small change I didn't think it needed to have a whole PR for itself, but let me know if you want I can do that too.

r? @philbooth 
