### PR TITLE
fix(config): ignore empty environment variables

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,7 +177,7 @@ dependencies = [
 
 [[package]]
 name = "config"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -566,7 +566,7 @@ version = "1.121.0"
 dependencies = [
  "base64 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "config 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "config 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "emailmessage 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "failure 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2433,7 +2433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum chrono 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e48d85528df61dc964aa43c5f6ca681a19cfa74939b2348d204bd08a981f2fb0"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum combine 3.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "de4d970a671fc33c6ac45b4535c0723104c7cf9d7b09ede7c020c131f9b40f40"
-"checksum config 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b5379dd8b3e7f488a31107d2c9586ce2ddbee2bc839201b3b38dbdf550351c1e"
+"checksum config 0.9.1 (registry+https://github.com/rust-lang/crates.io-index)" = "13490293b8a84cc82cd531da41adeae82cd9eaa40e926ac18865aa361f9c9f60"
 "checksum constant_time_eq 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8ff012e225ce166d4422e0e78419d901719760f62ae2b7969ca6b564d1b54a9e"
 "checksum cookie 0.11.0-dev (git+https://github.com/alexcrichton/cookie-rs?rev=f191ca50)" = "<none>"
 "checksum core-foundation 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "25bfd746d203017f7d5cbd31ee5d8e17f94b6521c7af77ece6c9e4b2d4b16c67"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/bin/queues.rs"
 [dependencies]
 base64 = ">=0.6.0"
 chrono = { version = ">=0.4.2", features = [ "serde" ] }
-config = ">=0.9.0"
+config = ">=0.9.1"
 emailmessage = ">=0.1.0"
 failure = ">=0.1.2"
 futures = ">=0.1.21,<0.2"

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -383,7 +383,7 @@ impl Settings {
         config.set_default("env", "dev")?;
 
         config.merge(File::with_name("config/local").required(false))?;
-        let env = Environment::with_prefix("fxa_email");
+        let env = Environment::with_prefix("fxa_email").ignore_empty(true);
         config.merge(env.separator("_"))?;
 
         match config.try_into::<Settings>() {

--- a/src/settings/test.rs
+++ b/src/settings/test.rs
@@ -559,3 +559,12 @@ fn invalid_sendgrid_api_key() {
         Err(error) => assert_eq!(error.description(), "configuration error"),
     }
 }
+
+#[test]
+fn empty_env_vars_are_ignored() {
+    let _clean_env = CleanEnvironment::new(vec!["FXA_EMAIL_PORT"]);
+
+    env::set_var("FXA_EMAIL_PORT", "");
+
+    assert!(Settings::new().is_ok());
+}


### PR DESCRIPTION
Fixes #191.

You can also test it manually by setting, say, `FXA_EMAIL_PORT` to the empty string and running `./r`. Before this change that fails with the error:

```
thread 'main' panicked at 'Settings::new error: invalid type: string "", expected an integer in the environment', libcore/result.rs:983:5
```

@mozilla/fxa-devs r?