### PR TITLE
refactor(types): prefer EmailAddress type to raw strings

### DIFF
--- a/src/app_errors/mod.rs
+++ b/src/app_errors/mod.rs
@@ -17,6 +17,7 @@ use rocket_contrib::{Json, JsonValue};
 use serde_json::{map::Map, ser::to_string, Value};
 
 use auth_db::BounceRecord;
+use email_address::EmailAddress;
 use logging::MozlogLogger;
 
 #[cfg(test)]
@@ -133,19 +134,19 @@ pub enum AppErrorKind {
     /// An error for when a bounce violation happens.
     #[fail(display = "Email account sent complaint")]
     BounceComplaintError {
-        address: String,
+        address: EmailAddress,
         bounced_at: u64,
         bounce: BounceRecord,
     },
     #[fail(display = "Email account soft bounced")]
     BounceSoftError {
-        address: String,
+        address: EmailAddress,
         bounced_at: u64,
         bounce: BounceRecord,
     },
     #[fail(display = "Email account hard bounced")]
     BounceHardError {
-        address: String,
+        address: EmailAddress,
         bounced_at: u64,
         bounce: BounceRecord,
     },
@@ -282,10 +283,7 @@ impl AppErrorKind {
                 ref bounced_at,
                 ref bounce,
             } => {
-                fields.insert(
-                    String::from("address"),
-                    Value::String(format!("{}", address)),
-                );
+                fields.insert(String::from("address"), Value::String(address.to_string()));
                 fields.insert(
                     String::from("bouncedAt"),
                     Value::Number(bounced_at.clone().into()),

--- a/src/auth_db/test.rs
+++ b/src/auth_db/test.rs
@@ -138,18 +138,8 @@ fn serialize_bounce_subtype() {
 fn get_bounces() {
     let settings = Settings::new().expect("config error");
     let db = DbClient::new(&settings);
-    if let Err(error) = db.get_bounces("foo@example.com") {
+    if let Err(error) = db.get_bounces(&"foo@example.com".parse().unwrap()) {
         assert!(false, format!("{}", error));
-    }
-}
-
-#[test]
-fn get_bounces_invalid_address() {
-    let settings = Settings::new().expect("config error");
-    let db = DbClient::new(&settings);
-    match db.get_bounces("") {
-        Ok(_) => assert!(false, "DbClient::get_bounces should have failed"),
-        Err(error) => assert_eq!(format!("{}", error), "400 Bad Request"),
     }
 }
 
@@ -200,12 +190,13 @@ fn create_bounce() {
     assert!(second_bounce.created_at > bounce.created_at);
 }
 
-fn generate_email_address(variant: &str) -> String {
+fn generate_email_address(variant: &str) -> EmailAddress {
     format!(
         "fxa-email-service.test.auth-db.{}.{}@example.com",
         variant,
         now_as_milliseconds()
-    )
+    ).parse()
+    .unwrap()
 }
 
 fn now_as_milliseconds() -> u64 {

--- a/src/email_address/mod.rs
+++ b/src/email_address/mod.rs
@@ -4,29 +4,54 @@
 
 //! Email address type.
 
-use serde::de::{Deserialize, Deserializer, Error, Unexpected};
+use std::{
+    fmt::{self, Display, Formatter},
+    str::FromStr,
+};
+
+use serde::de::{value::Error as DeserializeError, Deserialize, Deserializer, Error, Unexpected};
 
 use validate;
 
 #[cfg(test)]
 mod test;
 
-#[derive(Clone, Debug, Default, Serialize, PartialEq)]
-pub struct EmailAddress(pub String);
-
 /// Email address type.
 ///
-/// Validates and then lowercases the address during deserialization.
+/// Validates and then lowercases the address during parsing.
+#[derive(Clone, Debug, Default, Eq, Serialize, PartialEq)]
+pub struct EmailAddress(String);
+
+impl AsRef<str> for EmailAddress {
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
 impl<'d> Deserialize<'d> for EmailAddress {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: Deserializer<'d>,
     {
         let value: String = Deserialize::deserialize(deserializer)?;
+        value.parse().map_err(D::Error::custom)
+    }
+}
+
+impl Display for EmailAddress {
+    fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
+        write!(formatter, "{}", self.0)
+    }
+}
+
+impl FromStr for EmailAddress {
+    type Err = DeserializeError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
         if validate::email_address(&value) {
             Ok(EmailAddress(value.to_lowercase()))
         } else {
-            Err(D::Error::invalid_value(
+            Err(DeserializeError::invalid_value(
                 Unexpected::Str(&value),
                 &"email address",
             ))

--- a/src/email_address/test.rs
+++ b/src/email_address/test.rs
@@ -1,43 +1,53 @@
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
-// // file, you can obtain one at https://mozilla.org/MPL/2.0/.
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::error::Error;
 
 use serde_test::{assert_de_tokens, Token};
 
 use super::*;
 
-#[derive(Serialize, Deserialize, PartialEq, Debug)]
-struct TestEmailStruct {
-    email: EmailAddress,
+#[test]
+fn parse() {
+    let result = "foo@example.com".parse::<EmailAddress>();
+    assert!(result.is_ok());
+    match result {
+        Ok(email_address) => {
+            assert_eq!(email_address, EmailAddress(String::from("foo@example.com")));
+            assert_eq!(email_address.as_ref(), "foo@example.com");
+            assert_eq!(email_address.to_string(), "foo@example.com");
+        }
+        _ => {}
+    }
+
+    let result = "foo@".parse::<EmailAddress>();
+    assert!(result.is_err());
+    match result {
+        Err(error) => {
+            assert_eq!(
+                error.description(),
+                "invalid value: string \"foo@\", expected email address"
+            );
+        }
+        _ => {}
+    }
+
+    let result = "BAR@EXAMPLE.COM".parse::<EmailAddress>();
+    assert!(result.is_ok());
+    match result {
+        Ok(email_address) => {
+            assert_eq!(email_address.as_ref(), "bar@example.com");
+        }
+        _ => {}
+    }
 }
 
 #[test]
-fn always_lowercase_email() {
-    let expected = TestEmailStruct {
-        email: EmailAddress(String::from("foo@example.com")),
-    };
-    assert_de_tokens(
-        &expected,
-        &[
-            Token::Struct {
-                name: "TestEmailStruct",
-                len: 1,
-            },
-            Token::Str("email"),
-            Token::Str("foo@example.com"),
-            Token::StructEnd,
-        ],
-    );
-    assert_de_tokens(
-        &expected,
-        &[
-            Token::Struct {
-                name: "TestEmailStruct",
-                len: 1,
-            },
-            Token::Str("email"),
-            Token::Str("FOO@EXAMPLE.COM"),
-            Token::StructEnd,
-        ],
-    );
+fn deserialize() {
+    let expected = EmailAddress(String::from("foo@example.com"));
+
+    assert_de_tokens(&expected, &[Token::Str("foo@example.com")]);
+
+    assert_de_tokens(&expected, &[Token::Str("FOO@EXAMPLE.COM")]);
 }

--- a/src/providers/sendgrid.rs
+++ b/src/providers/sendgrid.rs
@@ -42,7 +42,7 @@ impl Provider for SendgridProvider {
     ) -> AppResult<String> {
         let mut message = Message::new();
         let mut from_address = EmailAddress::new();
-        from_address.set_email(&self.sender.address.0);
+        from_address.set_email(&self.sender.address.as_ref());
         from_address.set_name(&self.sender.name.0);
         message.set_from(from_address);
         message.set_subject(subject);

--- a/src/providers/ses/mod.rs
+++ b/src/providers/ses/mod.rs
@@ -44,7 +44,11 @@ impl SesProvider {
 
         SesProvider {
             client,
-            sender: format!("{} <{}>", settings.sender.name, settings.sender.address.0),
+            sender: format!(
+                "{} <{}>",
+                settings.sender.name,
+                settings.sender.address.as_ref()
+            ),
         }
     }
 }

--- a/src/providers/smtp.rs
+++ b/src/providers/smtp.rs
@@ -24,7 +24,7 @@ impl SmtpProvider {
             port: settings.smtp.port,
             _credentials: settings.smtp.credentials.clone(),
             sender: (
-                settings.sender.address.0.clone(),
+                settings.sender.address.to_string(),
                 settings.sender.name.0.clone(),
             ),
         }

--- a/src/providers/socketlabs.rs
+++ b/src/providers/socketlabs.rs
@@ -37,7 +37,7 @@ impl Provider for SocketLabsProvider {
         body_html: Option<&str>,
     ) -> AppResult<String> {
         let mut message = Message::new(
-            self.sender.address.0.clone(),
+            self.sender.address.to_string(),
             Some(self.sender.name.0.clone()),
         );
         message.add_to(to, None);

--- a/src/queues/mock.rs
+++ b/src/queues/mock.rs
@@ -34,9 +34,11 @@ impl Incoming for Queue {
                 bounce_message.notification.bounce = Some(Bounce {
                     bounce_type: BounceType::Permanent,
                     bounce_subtype: BounceSubtype::General,
-                    bounced_recipients: vec![String::from(
-                        "fxa-email-service.queues.mock.bounce@example.com",
-                    )],
+                    bounced_recipients: vec![
+                        "fxa-email-service.queues.mock.bounce@example.com"
+                            .parse()
+                            .unwrap(),
+                    ],
                     timestamp: Utc::now(),
                 });
                 bounce_message
@@ -46,9 +48,11 @@ impl Incoming for Queue {
                 let mut complaint_message = Message::default();
                 complaint_message.notification.notification_type = NotificationType::Complaint;
                 complaint_message.notification.complaint = Some(Complaint {
-                    complained_recipients: vec![String::from(
-                        "fxa-email-service.queues.mock.complaint@example.com",
-                    )],
+                    complained_recipients: vec![
+                        "fxa-email-service.queues.mock.complaint@example.com"
+                            .parse()
+                            .unwrap(),
+                    ],
                     timestamp: Utc::now(),
                     complaint_feedback_type: None,
                 });
@@ -60,9 +64,11 @@ impl Incoming for Queue {
                 delivery_message.notification.notification_type = NotificationType::Delivery;
                 delivery_message.notification.delivery = Some(Delivery {
                     timestamp: Utc::now(),
-                    recipients: vec![String::from(
-                        "fxa-email-service.queues.mock.delivery@example.com",
-                    )],
+                    recipients: vec![
+                        "fxa-email-service.queues.mock.delivery@example.com"
+                            .parse()
+                            .unwrap(),
+                    ],
                 });
                 delivery_message
             }
@@ -71,9 +77,11 @@ impl Incoming for Queue {
                 let mut invalid_message = Message::default();
                 invalid_message.notification.notification_type = NotificationType::Bounce;
                 invalid_message.notification.complaint = Some(Complaint {
-                    complained_recipients: vec![String::from(
-                        "fxa-email-service.queues.mock.complaint@example.com",
-                    )],
+                    complained_recipients: vec![
+                        "fxa-email-service.queues.mock.complaint@example.com"
+                            .parse()
+                            .unwrap(),
+                    ],
                     timestamp: Utc::now(),
                     complaint_feedback_type: None,
                 });

--- a/src/queues/notification.rs
+++ b/src/queues/notification.rs
@@ -9,6 +9,7 @@ use chrono::{DateTime, Utc};
 pub use super::sqs::notification::{
     BounceSubtype, BounceType, ComplaintFeedbackType, Header, HeaderValue, NotificationType,
 };
+use email_address::EmailAddress;
 
 /// The root notification type.
 ///
@@ -66,14 +67,14 @@ pub struct Bounce {
     pub bounce_type: BounceType,
     #[serde(rename = "bounceSubType")]
     pub bounce_subtype: BounceSubtype,
-    pub bounced_recipients: Vec<String>,
+    pub bounced_recipients: Vec<EmailAddress>,
     pub timestamp: DateTime<Utc>,
 }
 
 #[derive(Debug, Serialize)]
 pub struct Complaint {
     #[serde(rename = "complainedRecipients")]
-    pub complained_recipients: Vec<String>,
+    pub complained_recipients: Vec<EmailAddress>,
     #[serde(rename = "complaintFeedbackType")]
     pub complaint_feedback_type: Option<ComplaintFeedbackType>,
     pub timestamp: DateTime<Utc>,
@@ -82,5 +83,5 @@ pub struct Complaint {
 #[derive(Debug, Serialize)]
 pub struct Delivery {
     pub timestamp: DateTime<Utc>,
-    pub recipients: Vec<String>,
+    pub recipients: Vec<EmailAddress>,
 }

--- a/src/queues/sqs/notification/mod.rs
+++ b/src/queues/sqs/notification/mod.rs
@@ -17,6 +17,7 @@ use super::super::notification::{
     Mail as GenericMail, Notification as GenericNotification,
 };
 use auth_db::{BounceSubtype as AuthDbBounceSubtype, BounceType as AuthDbBounceType};
+use email_address::EmailAddress;
 
 #[cfg(test)]
 mod test;
@@ -283,7 +284,7 @@ impl<'d> Deserialize<'d> for BounceSubtype {
 #[derive(Debug, Deserialize)]
 pub struct BouncedRecipient {
     #[serde(rename = "emailAddress")]
-    pub email_address: String,
+    pub email_address: EmailAddress,
     pub action: Option<String>,
     pub status: Option<String>,
     #[serde(rename = "diagnosticCode")]
@@ -318,7 +319,7 @@ impl From<Complaint> for GenericComplaint {
 #[derive(Debug, Deserialize)]
 pub struct ComplainedRecipient {
     #[serde(rename = "emailAddress")]
-    pub email_address: String,
+    pub email_address: EmailAddress,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -385,7 +386,7 @@ impl Serialize for ComplaintFeedbackType {
 #[derive(Debug, Deserialize)]
 pub struct Delivery {
     pub timestamp: DateTime<Utc>,
-    pub recipients: Vec<String>,
+    pub recipients: Vec<EmailAddress>,
 }
 
 impl From<Delivery> for GenericDelivery {

--- a/src/queues/sqs/notification/test.rs
+++ b/src/queues/sqs/notification/test.rs
@@ -269,16 +269,16 @@ fn deserialize_notification() {
     };
     assert_eq!(bounce.bounced_recipients.len(), 3);
     assert_eq!(
-        bounce.bounced_recipients[0].email_address,
-        "bar@example.com".to_string()
+        bounce.bounced_recipients[0].email_address.as_ref(),
+        "bar@example.com"
     );
     assert_eq!(
-        bounce.bounced_recipients[1].email_address,
-        "baz@example.com".to_string()
+        bounce.bounced_recipients[1].email_address.as_ref(),
+        "baz@example.com"
     );
     assert_eq!(
-        bounce.bounced_recipients[2].email_address,
-        "qux@example.com".to_string()
+        bounce.bounced_recipients[2].email_address.as_ref(),
+        "qux@example.com"
     );
     assert_eq!(bounce.bounce_type, BounceType::Permanent);
     assert_eq!(bounce.bounce_subtype, BounceSubtype::General);
@@ -303,8 +303,8 @@ fn deserialize_notification() {
         _ => panic!("Complaint record should exist."),
     };
     assert_eq!(
-        complaint.complained_recipients[0].email_address,
-        "baz@example.com".to_string()
+        complaint.complained_recipients[0].email_address.as_ref(),
+        "baz@example.com"
     );
     assert_eq!(
         complaint.complaint_feedback_type,
@@ -330,5 +330,5 @@ fn deserialize_notification() {
         Some(ref record) => record,
         _ => panic!("Delivery record should exist."),
     };
-    assert_eq!(delivery.recipients[0], "xyzzy@example.com".to_string());
+    assert_eq!(delivery.recipients[0].as_ref(), "xyzzy@example.com");
 }

--- a/src/settings/test.rs
+++ b/src/settings/test.rs
@@ -143,7 +143,7 @@ fn env_vars_take_precedence() {
             let redis_host = format!("{}1", &settings.redis.host);
             let redis_port = settings.redis.port + 1;
             let secretkey = String::from("ampqampqampqampqampqampqampqampqampqampqamo=");
-            let sender_address = format!("1{}", &settings.sender.address.0);
+            let sender_address = format!("1{}", settings.sender.address.as_ref());
             let sender_name = format!("{}1", &settings.sender.name);
             let sendgrid_api_key = String::from(
                 "000000000000000000000000000000000000000000000000000000000000000000000",
@@ -254,7 +254,7 @@ fn env_vars_take_precedence() {
                     assert_eq!(env_settings.redis.host, Host(redis_host));
                     assert_eq!(env_settings.redis.port, redis_port);
                     assert_eq!(env_settings.secretkey, secretkey);
-                    assert_eq!(env_settings.sender.address, EmailAddress(sender_address));
+                    assert_eq!(env_settings.sender.address, sender_address.parse().unwrap());
                     assert_eq!(env_settings.sender.name, SenderName(sender_name));
                     assert_eq!(env_settings.smtp.host, Host(smtp_host));
                     assert_eq!(env_settings.smtp.port, smtp_port);


### PR DESCRIPTION
The EmailAddress type was only being used in some places, which meant some places that weren't using it had to call `validate::email_address` manually. This change spreads it throughout most of the project, so that almost everywhere gets to benefit from strong typing.

The only place I decided to leave alone was the provider layer, where some providers have their own `EmailAddress` struct. I could have aliased it at that layer too, but by that point addresses are just dumb strings anyway so it didn't seem worth it.

(this is an extraction from `pb/166-wip` because that branch is growing too big)

@mozilla/fxa-devs r?
