### PR TITLE
fix(ci): only build deployment artifacts for tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,5 +72,8 @@ workflows:
     jobs:
       - build:
           filters:
+            branches:
+              ignore: /.*/
+
             tags:
-              only: /.*/
+              only: /^v[0-9.]+$/


### PR DESCRIPTION
Fixes #195.

Compare, for example, #196 to this PR. There it has kicked off an [unnecessary Circle build](https://circleci.com/gh/mozilla/fxa-email-service/241), here we're only building in Travis.

@mozilla/fxa-devs r?