### PR TITLE
feat(db): serialize to JSON on write and deserialize from JSON on read

### DIFF
--- a/API.md
+++ b/API.md
@@ -35,6 +35,7 @@
 - `code: 500, errno: 117`: Db Error
 - `code: 500, errno: 118`: Not Implemeneted
 - `code: 500, errno: 119`: HMAC error
+- `code: 500, errno: 120`: JSON error
 
 The following errors include additional response properties:
 

--- a/src/app_errors/mod.rs
+++ b/src/app_errors/mod.rs
@@ -201,6 +201,10 @@ pub enum AppErrorKind {
     /// An error occured while hashing a value.
     #[fail(display = "HMAC error: {}", _0)]
     HmacError(String),
+
+    /// An error occured while serializing or deserializing JSON.
+    #[fail(display = "JSON error: {}", _0)]
+    JsonError(String),
 }
 
 impl AppErrorKind {
@@ -251,6 +255,8 @@ impl AppErrorKind {
             AppErrorKind::NotImplemented => Some(118),
 
             AppErrorKind::HmacError(_) => Some(119),
+
+            AppErrorKind::JsonError(_) => Some(120),
 
             AppErrorKind::BadRequest
             | AppErrorKind::NotFound

--- a/src/message_data/mod.rs
+++ b/src/message_data/mod.rs
@@ -41,6 +41,7 @@ impl MessageData {
     /// Any data previously stored for the message id
     /// will be replaced.
     pub fn set(&self, message_id: &str, metadata: &str) -> AppResult<()> {
-        self.client.set(message_id, metadata, DataType::MessageData)
+        self.client
+            .set(message_id, &metadata, DataType::MessageData)
     }
 }

--- a/src/message_data/test.rs
+++ b/src/message_data/test.rs
@@ -31,7 +31,7 @@ fn set() {
             .unwrap();
         assert!(!key_exists, "unhashed key should not exist in redis");
         let value: String = test.redis_client.get(test.internal_key.as_str()).unwrap();
-        assert_eq!(value, "wibble");
+        assert_eq!(value, "\"wibble\"");
     }
 }
 

--- a/src/queues/sqs/mod.rs
+++ b/src/queues/sqs/mod.rs
@@ -222,6 +222,6 @@ impl From<DeleteMessageError> for AppError {
 
 impl From<JsonError> for AppError {
     fn from(error: JsonError) -> AppError {
-        AppErrorKind::QueueError(format!("JSON error: {:?}", error)).into()
+        AppErrorKind::JsonError(format!("JSON error: {:?}", error)).into()
     }
 }


### PR DESCRIPTION
Related to #166.

Previously, our Redis abstraction only worked with strings because it only dealt with the somewhat nebulous concept of message metadata. Now that we also want to use it for concrete types, it makes sense to bake in automatic serialization from and deserialization to those types. This frees consumers from the responsibility of having to serialize to a Redis-friendly format manually.

This change achieves that aim by making the db methods generic. `db.set` gets a type parameter that is `Serialize` and the getters get one that is `DeserializeOwned`.

(this is the final extraction from `pb/166-wip` before I can open the actual pull request for that change)

@mozilla/fxa-devs r?