### PR TITLE
refactor(redis): stop treating no data as an error in the getters

### DIFF
--- a/src/message_data/mod.rs
+++ b/src/message_data/mod.rs
@@ -32,7 +32,7 @@ impl MessageData {
     /// This is a destructive operation.
     /// Once consumed,
     /// the data is permanently destroyed.
-    pub fn consume(&self, message_id: &str) -> AppResult<String> {
+    pub fn consume(&self, message_id: &str) -> AppResult<Option<String>> {
         self.client.consume(message_id, DataType::MessageData)
     }
 

--- a/src/message_data/test.rs
+++ b/src/message_data/test.rs
@@ -42,7 +42,10 @@ fn consume() {
         .set(test.unhashed_key.as_str(), "blee")
         .unwrap();
     assert_eq!(
-        test.message_data.consume(&test.unhashed_key).unwrap(),
+        test.message_data
+            .consume(&test.unhashed_key)
+            .unwrap()
+            .unwrap(),
         "blee"
     );
     let key_exists: bool = test
@@ -53,10 +56,12 @@ fn consume() {
         !key_exists,
         "internal key should not exist in redis after being consumed"
     );
-    match test.message_data.consume(&test.unhashed_key) {
-        Ok(_) => assert!(false, "consume should fail when called a second time"),
-        Err(error) => assert_eq!(format!("{}", error), "Redis error: Response was of incompatible type: \"Response type not string compatible.\" (response was nil)"),
-    }
+    assert!(
+        test.message_data
+            .consume(&test.unhashed_key)
+            .unwrap()
+            .is_none()
+    );
 }
 
 impl TestFixture {

--- a/src/queues/mod.rs
+++ b/src/queues/mod.rs
@@ -135,7 +135,8 @@ impl Queues {
                 notification.metadata = self
                     .message_data
                     .consume(&notification.mail.message_id)
-                    .ok();
+                    .ok()
+                    .unwrap_or(None);
                 let future = self
                     .notification_queue
                     .send(&notification)


### PR DESCRIPTION
This is another extraction from the branch for #166.

Previously, we were treating an absence of data as an error case in Redis. That's wrong for every data type we plan to store, so this PR changes the `db` module to wrap its result types in an `Option`.

@mozilla/fxa-devs r?