### PR TITLE
feat(db): write bounce and complaint records to our own db

### DIFF
--- a/src/auth_db/mod.rs
+++ b/src/auth_db/mod.rs
@@ -22,7 +22,7 @@ use hex;
 use reqwest::{Client as RequestClient, Error as RequestError, StatusCode, Url, UrlError};
 
 use app_errors::{AppError, AppErrorKind, AppResult};
-use delivery_problems::{DeliveryProblem, ProblemSubtype, ProblemType};
+use delivery_problems::{LegacyDeliveryProblem as DeliveryProblem, ProblemSubtype, ProblemType};
 use email_address::EmailAddress;
 use settings::Settings;
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -12,6 +12,9 @@
 //! You can read more about this decision
 //! in [#166](https://github.com/mozilla/fxa-email-service/issues/166).
 
+#[cfg(test)]
+pub mod test;
+
 use std::fmt::{self, Display, Formatter};
 
 use hmac::{crypto_mac::InvalidKeyLength, Hmac, Mac};
@@ -109,17 +112,19 @@ pub enum DataType {
     MessageData,
 }
 
+impl AsRef<str> for DataType {
+    fn as_ref(&self) -> &str {
+        match *self {
+            DataType::Configuration => "cfg",
+            DataType::DeliveryProblem => "del",
+            DataType::MessageData => "msg",
+        }
+    }
+}
+
 impl Display for DataType {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(
-            formatter,
-            "{}",
-            match *self {
-                DataType::Configuration => "cfg",
-                DataType::DeliveryProblem => "del",
-                DataType::MessageData => "msg",
-            }
-        )
+        write!(formatter, "{}", self.as_ref())
     }
 }
 

--- a/src/db/test.rs
+++ b/src/db/test.rs
@@ -1,0 +1,66 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Test logic for `db` consumers.
+
+use std::fmt::Debug;
+
+use super::*;
+
+/// A test fixture for `db` consumers,
+/// with logic for asserting
+/// that data is being written
+/// to the underlying store correctly.
+#[derive(Debug)]
+pub struct TestFixture {
+    unhashed_key: String,
+    internal_key: String,
+    redis_client: RedisClient,
+}
+
+impl TestFixture {
+    pub fn setup(settings: &Settings, unhashed_key: &str, data_type: DataType) -> Self {
+        let mut hmac = Hmac::<Sha256>::new_varkey(settings.hmackey.as_bytes()).unwrap();
+        hmac.input(unhashed_key.as_bytes());
+        let internal_key = format!("{}:{:x}", data_type.as_ref(), hmac.result().code());
+        Self {
+            unhashed_key: String::from(unhashed_key),
+            internal_key,
+            redis_client: RedisClient::open(
+                format!("redis://{}:{}/", settings.redis.host, settings.redis.port).as_str(),
+            ).unwrap(),
+        }
+    }
+
+    pub fn key(&self) -> &str {
+        &self.unhashed_key
+    }
+
+    pub fn assert_not_set(&self) {
+        let exists: bool = self.redis_client.exists(&self.internal_key).unwrap();
+        assert!(!exists);
+    }
+
+    pub fn assert_set(&self) {
+        let exists: bool = self.redis_client.exists(&self.internal_key).unwrap();
+        assert!(exists);
+
+        let exists: bool = self.redis_client.exists(&self.unhashed_key).unwrap();
+        assert!(!exists);
+    }
+
+    pub fn assert_data<D>(&self, expected: D)
+    where
+        D: Debug + DeserializeOwned + PartialEq,
+    {
+        self.assert_set();
+
+        let data: D = self
+            .redis_client
+            .get(&self.internal_key)
+            .map(|value: String| serde_json::from_str(&value).unwrap())
+            .unwrap();
+        assert_eq!(data, expected);
+    }
+}

--- a/src/delivery_problems/mod.rs
+++ b/src/delivery_problems/mod.rs
@@ -16,17 +16,23 @@ use serde::{
 
 use app_errors::{AppErrorKind, AppResult};
 use auth_db::Db as AuthDb;
+use db::{Client as DbClient, DataType};
 use email_address::EmailAddress;
 use queues::notification::{BounceSubtype, BounceType, ComplaintFeedbackType};
 use settings::{BounceLimit, BounceLimits, Settings};
 
 /// Bounce/complaint registry.
 ///
-/// Currently just a thing wrapper
-/// around the `emailBounces` table in `fxa-auth-db-mysql`.
+/// Currently this writes to both
+/// Redis and the `emailBounces` table in `fxa-auth-db-mysql`,
+/// but only reads from the latter.
+/// This is the first step
+/// in a gradual migration process
+/// away from the auth db.
 #[derive(Debug)]
 pub struct DeliveryProblems<D: AuthDb> {
     auth_db: D,
+    db: DbClient,
     limits: BounceLimits,
 }
 
@@ -38,6 +44,7 @@ where
     pub fn new(settings: &Settings, auth_db: D) -> DeliveryProblems<D> {
         DeliveryProblems {
             auth_db,
+            db: DbClient::new(settings),
             limits: settings.bouncelimits.clone(),
         }
     }
@@ -53,10 +60,7 @@ where
     /// [limits]: ../settings/struct.BounceLimits.html
     pub fn check(&self, address: &EmailAddress) -> AppResult<()> {
         let problems = self.auth_db.get_bounces(address)?;
-        let now = SystemTime::now()
-            .duration_since(SystemTime::UNIX_EPOCH)
-            .expect("system time error");
-        let now = now.as_secs() * 1000;
+        let timestamp = now();
         problems
             .iter()
             .try_fold(HashMap::new(), |mut counts, problem| {
@@ -68,7 +72,7 @@ where
                         ProblemType::SoftBounce => &self.limits.soft,
                         ProblemType::Complaint => &self.limits.complaint,
                     };
-                    if is_limit_violation(*count, problem.created_at, now, limits) {
+                    if is_limit_violation(*count, problem.created_at, timestamp, limits) {
                         return match problem.problem_type {
                             ProblemType::HardBounce => Err(AppErrorKind::BounceHardError {
                                 address: address.clone(),
@@ -101,8 +105,35 @@ where
         bounce_type: BounceType,
         bounce_subtype: BounceSubtype,
     ) -> AppResult<()> {
+        let problem_type: ProblemType = From::from(bounce_type);
+        let problem_subtype: ProblemSubtype = From::from(bounce_subtype);
         self.auth_db
-            .create_bounce(address, From::from(bounce_type), From::from(bounce_subtype))?;
+            .create_bounce(address, problem_type, problem_subtype)?;
+        self.record_delivery_problem(address, problem_type, problem_subtype)?;
+        Ok(())
+    }
+
+    fn record_delivery_problem(
+        &self,
+        address: &EmailAddress,
+        problem_type: ProblemType,
+        problem_subtype: ProblemSubtype,
+    ) -> AppResult<()> {
+        let mut problems: Vec<DeliveryProblem> = self
+            .db
+            .get(address.as_ref(), DataType::DeliveryProblem)?
+            .unwrap_or_else(|| Vec::new());
+        problems.insert(
+            0,
+            DeliveryProblem {
+                address: address.clone(),
+                problem_type,
+                problem_subtype,
+                created_at: now(),
+            },
+        );
+        self.db
+            .set(address.as_ref(), &problems, DataType::DeliveryProblem)?;
         Ok(())
     }
 
@@ -113,23 +144,31 @@ where
         address: &EmailAddress,
         complaint_type: Option<ComplaintFeedbackType>,
     ) -> AppResult<()> {
-        let bounce_subtype = complaint_type.map_or(ProblemSubtype::Unmapped, |ct| From::from(ct));
+        let problem_subtype = complaint_type.map_or(ProblemSubtype::Unmapped, |ct| From::from(ct));
         self.auth_db
-            .create_bounce(address, ProblemType::Complaint, bounce_subtype)?;
+            .create_bounce(address, ProblemType::Complaint, problem_subtype)?;
+        self.record_delivery_problem(address, ProblemType::Complaint, problem_subtype)?;
         Ok(())
     }
 }
 
 unsafe impl<D> Sync for DeliveryProblems<D> where D: AuthDb {}
 
-fn is_limit_violation(count: u8, created_at: u64, now: u64, limits: &[BounceLimit]) -> bool {
+fn is_limit_violation(count: u8, created_at: u64, timestamp: u64, limits: &[BounceLimit]) -> bool {
     for limit in limits.iter() {
-        if count > limit.limit && created_at >= now - limit.period.0 {
+        if count > limit.limit && created_at >= timestamp - limit.period.0 {
             return true;
         }
     }
 
     false
+}
+
+fn now() -> u64 {
+    let now = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("system time error");
+    now.as_secs() * 1000 + u64::from(now.subsec_millis())
 }
 
 /// Encapsulates some kind of delivery problem,

--- a/src/delivery_problems/mod.rs
+++ b/src/delivery_problems/mod.rs
@@ -123,17 +123,24 @@ where
             .db
             .get(address.as_ref(), DataType::DeliveryProblem)?
             .unwrap_or_else(|| Vec::new());
-        problems.insert(
-            0,
-            DeliveryProblem {
-                address: address.clone(),
-                problem_type,
-                problem_subtype,
-                created_at: now(),
-            },
-        );
+
+        // TODO: A direct port of the auth db behaviour here would insert at the
+        //       start rather than append to the end of the list. But it's more
+        //       efficient for us to append here and then process the list in
+        //       reverse instead. So when we come to processing data from this
+        //       data store, we must be careful to call `.rev()` beforehand (but
+        //       hopefully that will also be obvious from the failing tests without
+        //       needing to rely on this comment).
+        problems.push(DeliveryProblem {
+            address: address.clone(),
+            problem_type,
+            problem_subtype,
+            created_at: now(),
+        });
+
         self.db
             .set(address.as_ref(), &problems, DataType::DeliveryProblem)?;
+
         Ok(())
     }
 

--- a/src/delivery_problems/test.rs
+++ b/src/delivery_problems/test.rs
@@ -57,22 +57,22 @@ fn create_settings(bounce_limits: Json) -> Settings {
 pub struct DbMockNoBounce;
 
 impl Db for DbMockNoBounce {
-    fn get_bounces(&self, _address: &EmailAddress) -> AppResult<Vec<DeliveryProblem>> {
+    fn get_bounces(&self, _address: &EmailAddress) -> AppResult<Vec<LegacyDeliveryProblem>> {
         let now = now_as_milliseconds();
         Ok(vec![
-            DeliveryProblem {
+            LegacyDeliveryProblem {
                 address: "foo@example.com".parse().unwrap(),
                 problem_type: ProblemType::SoftBounce,
                 problem_subtype: ProblemSubtype::Undetermined,
                 created_at: now - DAY - 1000,
             },
-            DeliveryProblem {
+            LegacyDeliveryProblem {
                 address: "foo@example.com".parse().unwrap(),
                 problem_type: ProblemType::HardBounce,
                 problem_subtype: ProblemSubtype::Undetermined,
                 created_at: now - WEEK - 1000,
             },
-            DeliveryProblem {
+            LegacyDeliveryProblem {
                 address: "foo@example.com".parse().unwrap(),
                 problem_type: ProblemType::Complaint,
                 problem_subtype: ProblemSubtype::Undetermined,
@@ -118,8 +118,8 @@ fn check_soft_bounce() {
             let problem = err_data.get("problem");
             assert!(problem.is_some());
             let record: Json = serde_json::from_str(problem.unwrap().as_str().unwrap()).unwrap();
-            assert_eq!(record["bounceType"], 2);
-            assert_eq!(&record["createdAt"], err_data.get("time").unwrap());
+            assert_eq!(record["problem_type"], 2);
+            assert_eq!(&record["created_at"], err_data.get("time").unwrap());
             assert_eq!(error.kind().http_status(), Status::TooManyRequests);
         }
     }
@@ -129,9 +129,9 @@ fn check_soft_bounce() {
 pub struct DbMockBounceSoft;
 
 impl Db for DbMockBounceSoft {
-    fn get_bounces(&self, _address: &EmailAddress) -> AppResult<Vec<DeliveryProblem>> {
+    fn get_bounces(&self, _address: &EmailAddress) -> AppResult<Vec<LegacyDeliveryProblem>> {
         let now = now_as_milliseconds();
-        Ok(vec![DeliveryProblem {
+        Ok(vec![LegacyDeliveryProblem {
             address: "foo@example.com".parse().unwrap(),
             problem_type: ProblemType::SoftBounce,
             problem_subtype: ProblemSubtype::Undetermined,
@@ -169,8 +169,8 @@ fn check_hard_bounce() {
             let problem = err_data.get("problem");
             assert!(problem.is_some());
             let record: Json = serde_json::from_str(problem.unwrap().as_str().unwrap()).unwrap();
-            assert_eq!(record["bounceType"], 1);
-            assert_eq!(&record["createdAt"], err_data.get("time").unwrap());
+            assert_eq!(record["problem_type"], 1);
+            assert_eq!(&record["created_at"], err_data.get("time").unwrap());
             assert_eq!(error.kind().http_status(), Status::TooManyRequests);
         }
     }
@@ -180,9 +180,9 @@ fn check_hard_bounce() {
 pub struct DbMockBounceHard;
 
 impl Db for DbMockBounceHard {
-    fn get_bounces(&self, _address: &EmailAddress) -> AppResult<Vec<DeliveryProblem>> {
+    fn get_bounces(&self, _address: &EmailAddress) -> AppResult<Vec<LegacyDeliveryProblem>> {
         let now = now_as_milliseconds();
-        Ok(vec![DeliveryProblem {
+        Ok(vec![LegacyDeliveryProblem {
             address: "bar@example.com".parse().unwrap(),
             problem_type: ProblemType::HardBounce,
             problem_subtype: ProblemSubtype::Undetermined,
@@ -220,8 +220,8 @@ fn check_complaint() {
             let problem = err_data.get("problem");
             assert!(problem.is_some());
             let record: Json = serde_json::from_str(problem.unwrap().as_str().unwrap()).unwrap();
-            assert_eq!(record["bounceType"], 3);
-            assert_eq!(&record["createdAt"], err_data.get("time").unwrap());
+            assert_eq!(record["problem_type"], 3);
+            assert_eq!(&record["created_at"], err_data.get("time").unwrap());
             assert_eq!(error.kind().http_status(), Status::TooManyRequests);
         }
     }
@@ -231,9 +231,9 @@ fn check_complaint() {
 pub struct DbMockComplaint;
 
 impl Db for DbMockComplaint {
-    fn get_bounces(&self, _address: &EmailAddress) -> AppResult<Vec<DeliveryProblem>> {
+    fn get_bounces(&self, _address: &EmailAddress) -> AppResult<Vec<LegacyDeliveryProblem>> {
         let now = now_as_milliseconds();
-        Ok(vec![DeliveryProblem {
+        Ok(vec![LegacyDeliveryProblem {
             address: "baz@example.com".parse().unwrap(),
             problem_type: ProblemType::Complaint,
             problem_subtype: ProblemSubtype::Undetermined,
@@ -274,7 +274,7 @@ fn check_db_error() {
 pub struct DbMockError;
 
 impl Db for DbMockError {
-    fn get_bounces(&self, _address: &EmailAddress) -> AppResult<Vec<DeliveryProblem>> {
+    fn get_bounces(&self, _address: &EmailAddress) -> AppResult<Vec<LegacyDeliveryProblem>> {
         Err(AppErrorKind::AuthDbError(String::from("wibble blee")).into())
     }
 }
@@ -307,58 +307,58 @@ fn check_no_bounces_with_nonzero_limits() {
 pub struct DbMockNoBounceWithNonZeroLimits;
 
 impl Db for DbMockNoBounceWithNonZeroLimits {
-    fn get_bounces(&self, _address: &EmailAddress) -> AppResult<Vec<DeliveryProblem>> {
+    fn get_bounces(&self, _address: &EmailAddress) -> AppResult<Vec<LegacyDeliveryProblem>> {
         let now = now_as_milliseconds();
         Ok(vec![
-            DeliveryProblem {
+            LegacyDeliveryProblem {
                 address: "foo@example.com".parse().unwrap(),
                 problem_type: ProblemType::SoftBounce,
                 problem_subtype: ProblemSubtype::Undetermined,
                 created_at: now - DAY + MINUTE,
             },
-            DeliveryProblem {
+            LegacyDeliveryProblem {
                 address: "foo@example.com".parse().unwrap(),
                 problem_type: ProblemType::HardBounce,
                 problem_subtype: ProblemSubtype::Undetermined,
                 created_at: now - WEEK + MINUTE,
             },
-            DeliveryProblem {
+            LegacyDeliveryProblem {
                 address: "foo@example.com".parse().unwrap(),
                 problem_type: ProblemType::Complaint,
                 problem_subtype: ProblemSubtype::Undetermined,
                 created_at: now - MONTH + MINUTE,
             },
-            DeliveryProblem {
+            LegacyDeliveryProblem {
                 address: "foo@example.com".parse().unwrap(),
                 problem_type: ProblemType::SoftBounce,
                 problem_subtype: ProblemSubtype::Undetermined,
                 created_at: now - DAY + SECOND * 2,
             },
-            DeliveryProblem {
+            LegacyDeliveryProblem {
                 address: "foo@example.com".parse().unwrap(),
                 problem_type: ProblemType::HardBounce,
                 problem_subtype: ProblemSubtype::Undetermined,
                 created_at: now - WEEK + SECOND * 2,
             },
-            DeliveryProblem {
+            LegacyDeliveryProblem {
                 address: "foo@example.com".parse().unwrap(),
                 problem_type: ProblemType::Complaint,
                 problem_subtype: ProblemSubtype::Undetermined,
                 created_at: now - MONTH + SECOND * 2,
             },
-            DeliveryProblem {
+            LegacyDeliveryProblem {
                 address: "foo@example.com".parse().unwrap(),
                 problem_type: ProblemType::SoftBounce,
                 problem_subtype: ProblemSubtype::Undetermined,
                 created_at: now - DAY - 1000,
             },
-            DeliveryProblem {
+            LegacyDeliveryProblem {
                 address: "foo@example.com".parse().unwrap(),
                 problem_type: ProblemType::HardBounce,
                 problem_subtype: ProblemSubtype::Undetermined,
                 created_at: now - WEEK - 1000,
             },
-            DeliveryProblem {
+            LegacyDeliveryProblem {
                 address: "foo@example.com".parse().unwrap(),
                 problem_type: ProblemType::Complaint,
                 problem_subtype: ProblemSubtype::Undetermined,
@@ -399,8 +399,8 @@ fn check_bounce_with_multiple_limits() {
             let problem = err_data.get("problem");
             assert!(problem.is_some());
             let record: Json = serde_json::from_str(problem.unwrap().as_str().unwrap()).unwrap();
-            assert_eq!(record["bounceType"], 2);
-            assert_eq!(&record["createdAt"], err_data.get("time").unwrap());
+            assert_eq!(record["problem_type"], 2);
+            assert_eq!(&record["created_at"], err_data.get("time").unwrap());
         }
     }
 }
@@ -409,28 +409,28 @@ fn check_bounce_with_multiple_limits() {
 pub struct DbMockBounceWithMultipleLimits;
 
 impl Db for DbMockBounceWithMultipleLimits {
-    fn get_bounces(&self, _address: &EmailAddress) -> AppResult<Vec<DeliveryProblem>> {
+    fn get_bounces(&self, _address: &EmailAddress) -> AppResult<Vec<LegacyDeliveryProblem>> {
         let now = now_as_milliseconds();
         Ok(vec![
-            DeliveryProblem {
+            LegacyDeliveryProblem {
                 address: "foo@example.com".parse().unwrap(),
                 problem_type: ProblemType::SoftBounce,
                 problem_subtype: ProblemSubtype::Undetermined,
                 created_at: now - SECOND * 4,
             },
-            DeliveryProblem {
+            LegacyDeliveryProblem {
                 address: "foo@example.com".parse().unwrap(),
                 problem_type: ProblemType::SoftBounce,
                 problem_subtype: ProblemSubtype::Undetermined,
                 created_at: now - MINUTE * 2 + SECOND * 4,
             },
-            DeliveryProblem {
+            LegacyDeliveryProblem {
                 address: "foo@example.com".parse().unwrap(),
                 problem_type: ProblemType::SoftBounce,
                 problem_subtype: ProblemSubtype::Undetermined,
                 created_at: now - MINUTE * 2 + SECOND * 3,
             },
-            DeliveryProblem {
+            LegacyDeliveryProblem {
                 address: "foo@example.com".parse().unwrap(),
                 problem_type: ProblemType::SoftBounce,
                 problem_subtype: ProblemSubtype::Undetermined,
@@ -537,16 +537,13 @@ fn record_complaint() {
 
 #[derive(Debug, Deserialize, Eq, PartialEq)]
 struct AssertFriendlyDeliveryProblem {
-    #[serde(rename = "email")]
     pub address: EmailAddress,
-    #[serde(rename = "bounceType")]
     pub problem_type: ProblemType,
-    #[serde(rename = "bounceSubType")]
     pub problem_subtype: ProblemSubtype,
 }
 
-impl From<DeliveryProblem> for AssertFriendlyDeliveryProblem {
-    fn from(source: DeliveryProblem) -> Self {
+impl From<LegacyDeliveryProblem> for AssertFriendlyDeliveryProblem {
+    fn from(source: LegacyDeliveryProblem) -> Self {
         Self {
             address: source.address,
             problem_type: source.problem_type,

--- a/src/delivery_problems/test.rs
+++ b/src/delivery_problems/test.rs
@@ -487,6 +487,7 @@ fn record_bounce() {
         // created_at is probably a millisecond or two different between MySQL and Redis
         bounce_records
             .into_iter()
+            .rev()
             .map(From::from)
             .collect::<Vec<AssertFriendlyDeliveryProblem>>(),
     );


### PR DESCRIPTION
Related to #166.

This is the first step towards migrating away from the FxA auth db. We'll start by dual-writing to both databases. Then, after we've got sufficient history to fully evaluate limit violations using our own data, we can switch over to read from our own datastore and ditch the auth db.

Note that we still need to migrate from the auth server's bounce and complaint handling logic in prod before this code starts doing anything.

@mozilla/fxa-devs r?