### PR TITLE
fix(queues): fix the serialized format of outgoing notifications

### DIFF
--- a/src/queues/notification.rs
+++ b/src/queues/notification.rs
@@ -67,6 +67,7 @@ pub struct Bounce {
     pub bounce_type: BounceType,
     #[serde(rename = "bounceSubType")]
     pub bounce_subtype: BounceSubtype,
+    #[serde(rename = "bouncedRecipients")]
     pub bounced_recipients: Vec<EmailAddress>,
     pub timestamp: DateTime<Utc>,
 }


### PR DESCRIPTION
The `bounced_recipients` property of the outgoing notification structure was missing a serde `rename` attribute. That problem went undetected because we had no test coverage for the outgoing structure, which was a pretty large hole in our coverage. This change fixes the issue and adds some serialization assertions.

@mozilla/fxa-devs r?