### PR TITLE
fix(code): implement AsRef<str> to expose cheaper &str access

### DIFF
--- a/src/auth_db/mod.rs
+++ b/src/auth_db/mod.rs
@@ -99,7 +99,12 @@ struct DbUrls {
 
 impl DbUrls {
     pub fn new(settings: &Settings) -> DbUrls {
-        let base_uri: Url = settings.authdb.baseuri.0.parse().expect("invalid base URI");
+        let base_uri: Url = settings
+            .authdb
+            .baseuri
+            .as_ref()
+            .parse()
+            .expect("invalid base URI");
         DbUrls {
             get_bounces: base_uri.join("emailBounces/").expect("invalid base URI"),
             create_bounce: base_uri.join("emailBounces").expect("invalid base URI"),

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -115,7 +115,7 @@ pub struct MozlogLogger(pub slog::Logger);
 impl MozlogLogger {
     /// Construct a logger.
     pub fn new(settings: &Settings) -> Result<MozlogLogger, Error> {
-        let logger = match &*settings.log.format.0.as_ref() {
+        let logger = match settings.log.format.as_ref() {
             "mozlog" => {
                 let drain = MozLogJson::new(io::stdout())
                     .logger_name(LOGGER_NAME.to_owned())

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -125,7 +125,7 @@ impl Providers {
         }
 
         Providers {
-            default_provider: settings.provider.default.0.clone(),
+            default_provider: settings.provider.default.to_string(),
             force_default_provider: settings.provider.forcedefault,
             providers,
         }

--- a/src/providers/sendgrid.rs
+++ b/src/providers/sendgrid.rs
@@ -24,7 +24,7 @@ pub struct SendgridProvider {
 impl SendgridProvider {
     pub fn new(sendgrid_settings: &SendgridSettings, settings: &Settings) -> SendgridProvider {
         SendgridProvider {
-            client: Client::new(sendgrid_settings.key.0.clone()),
+            client: Client::new(sendgrid_settings.key.to_string()),
             sender: settings.sender.clone(),
         }
     }
@@ -43,7 +43,7 @@ impl Provider for SendgridProvider {
         let mut message = Message::new();
         let mut from_address = EmailAddress::new();
         from_address.set_email(&self.sender.address.as_ref());
-        from_address.set_name(&self.sender.name.0);
+        from_address.set_name(self.sender.name.as_ref());
         message.set_from(from_address);
         message.set_subject(subject);
 

--- a/src/providers/ses/mod.rs
+++ b/src/providers/ses/mod.rs
@@ -26,13 +26,13 @@ impl SesProvider {
         let region = settings
             .aws
             .region
-            .0
+            .as_ref()
             .parse::<Region>()
             .expect("invalid region");
 
         let client: Box<Ses> = if let Some(ref keys) = settings.aws.keys {
             let creds =
-                StaticProvider::new(keys.access.0.clone(), keys.secret.0.clone(), None, None);
+                StaticProvider::new(keys.access.to_string(), keys.secret.to_string(), None, None);
             Box::new(SesClient::new_with(
                 HttpClient::new().expect("Couldn't start HTTP Client."),
                 creds,

--- a/src/providers/smtp.rs
+++ b/src/providers/smtp.rs
@@ -20,12 +20,12 @@ pub struct SmtpProvider {
 impl SmtpProvider {
     pub fn new(settings: &Settings) -> SmtpProvider {
         SmtpProvider {
-            host: settings.smtp.host.0.clone(),
+            host: settings.smtp.host.to_string(),
             port: settings.smtp.port,
             _credentials: settings.smtp.credentials.clone(),
             sender: (
                 settings.sender.address.to_string(),
-                settings.sender.name.0.clone(),
+                settings.sender.name.to_string(),
             ),
         }
     }

--- a/src/providers/socketlabs.rs
+++ b/src/providers/socketlabs.rs
@@ -38,7 +38,7 @@ impl Provider for SocketLabsProvider {
     ) -> AppResult<String> {
         let mut message = Message::new(
             self.sender.address.to_string(),
-            Some(self.sender.name.0.clone()),
+            Some(self.sender.name.to_string()),
         );
         message.add_to(to, None);
         for address in cc.iter() {

--- a/src/queues/sqs/mod.rs
+++ b/src/queues/sqs/mod.rs
@@ -102,13 +102,13 @@ impl Factory for Queue {
         let region = settings
             .aws
             .region
-            .0
+            .as_ref()
             .parse::<Region>()
             .expect("invalid region");
 
         let client: Box<Sqs> = if let Some(ref keys) = settings.aws.keys {
             let creds =
-                StaticProvider::new(keys.access.0.clone(), keys.secret.0.clone(), None, None);
+                StaticProvider::new(keys.access.to_string(), keys.secret.to_string(), None, None);
             Box::new(SqsClient::new_with(
                 HttpClient::new().expect("Couldn't start HTTP Client."),
                 creds,

--- a/src/queues/sqs/notification/mod.rs
+++ b/src/queues/sqs/notification/mod.rs
@@ -69,20 +69,20 @@ pub enum NotificationType {
     Null,
 }
 
-impl From<NotificationType> for String {
-    fn from(notification_type: NotificationType) -> String {
-        String::from(match notification_type {
+impl AsRef<str> for NotificationType {
+    fn as_ref(&self) -> &str {
+        match *self {
             NotificationType::Bounce => "Bounce",
             NotificationType::Complaint => "Complaint",
             NotificationType::Delivery => "Delivery",
             NotificationType::Null => "",
-        })
+        }
     }
 }
 
 impl Display for NotificationType {
     fn fmt(&self, formatter: &mut Formatter) -> fmt::Result {
-        write!(formatter, "{}", From::from(*self): String)
+        write!(formatter, "{}", self.as_ref())
     }
 }
 
@@ -115,11 +115,11 @@ impl Serialize for NotificationType {
     where
         S: Serializer,
     {
-        let string: String = From::from(*self);
+        let string = self.as_ref();
         if string == "" {
             Err(S::Error::custom("notification type not set"))
         } else {
-            serializer.serialize_str(&string)
+            serializer.serialize_str(string)
         }
     }
 }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -31,6 +31,12 @@ macro_rules! deserialize_and_validate {
         #[derive(Clone, Debug, Default, Serialize, PartialEq)]
         pub struct $type(pub String);
 
+        impl AsRef<str> for $type {
+            fn as_ref(&self) -> &str {
+                self.0.as_str()
+            }
+        }
+
         impl Display for $type {
             fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
                 f.write_str(&self.0)


### PR DESCRIPTION
Fixes #211.

For a bunch of types in `src/settings.rs` and for `NotificationType` in `src/queues/sqs/notification/mod.rs`, we were allocating `String` instances when it wasn't always necessary. Where a slice can be used, it's preferable.

At the same time, I removed a load of `.0` inner type access for the newtype structs in `Settings`, because that notation is leaky (if we want to refactor the struct to something else, all the usage must change too).

No actual functionality is changed here, so there are no test changes.

@mozilla/fxa-devs r?