### PR TITLE
refactor(errors): stop exposing AppErrorKind directly from AppError

### DIFF
--- a/src/api/send/test.rs
+++ b/src/api/send/test.rs
@@ -218,7 +218,8 @@ fn missing_to_field() {
 
     let body = response.body().unwrap().into_string().unwrap();
     let error: AppError = AppErrorKind::MissingEmailParams(String::from("")).into();
-    assert_eq!(body, error.json().to_string());
+    let expected = serde_json::to_string(&error).unwrap();
+    assert_eq!(body, expected);
 }
 
 #[test]
@@ -243,7 +244,8 @@ fn missing_subject_field() {
 
     let body = response.body().unwrap().into_string().unwrap();
     let error: AppError = AppErrorKind::MissingEmailParams(String::from("")).into();
-    assert_eq!(body, error.json().to_string());
+    let expected = serde_json::to_string(&error).unwrap();
+    assert_eq!(body, expected);
 }
 
 #[test]
@@ -269,7 +271,8 @@ fn missing_body_text_field() {
 
     let body = response.body().unwrap().into_string().unwrap();
     let error: AppError = AppErrorKind::MissingEmailParams(String::from("")).into();
-    assert_eq!(body, error.json().to_string());
+    let expected = serde_json::to_string(&error).unwrap();
+    assert_eq!(body, expected);
 }
 
 #[test]
@@ -295,7 +298,8 @@ fn invalid_to_field() {
 
     let body = response.body().unwrap().into_string().unwrap();
     let error: AppError = AppErrorKind::MissingEmailParams(String::from("")).into();
-    assert_eq!(body, error.json().to_string());
+    let expected = serde_json::to_string(&error).unwrap();
+    assert_eq!(body, expected);
 }
 
 #[test]
@@ -322,5 +326,6 @@ fn invalid_cc_field() {
 
     let body = response.body().unwrap().into_string().unwrap();
     let error: AppError = AppErrorKind::MissingEmailParams(String::from("")).into();
-    assert_eq!(body, error.json().to_string());
+    let expected = serde_json::to_string(&error).unwrap();
+    assert_eq!(body, expected);
 }

--- a/src/db/delivery_problems/test.rs
+++ b/src/db/delivery_problems/test.rs
@@ -108,25 +108,22 @@ fn check_soft_bounce() {
     let settings = create_settings(bounce_settings);
     let db = DbMockBounceSoft;
     let problems = DeliveryProblems::new(&settings, db);
-    match problems.check(&"foo@example.com".parse().unwrap()) {
-        Ok(_) => assert!(false, "DeliveryProblems::check should have failed"),
-        Err(error) => {
-            assert_eq!(format!("{}", error), "Email account soft bounced");
-            let err_data = error.kind().additional_fields();
-            let address = err_data.get("address");
-            if let Some(ref address) = address {
-                assert_eq!("foo@example.com", address.as_str().unwrap());
-            } else {
-                assert!(false, "Error::address should be set");
-            }
-            let problem = err_data.get("problem");
-            assert!(problem.is_some());
-            let record: Json = serde_json::from_str(problem.unwrap().as_str().unwrap()).unwrap();
-            assert_eq!(record["problem_type"], 2);
-            assert_eq!(&record["created_at"], err_data.get("time").unwrap());
-            assert_eq!(error.kind().http_status(), Status::TooManyRequests);
-        }
-    }
+    let result = problems.check(&"foo@example.com".parse().unwrap());
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    assert_eq!(error.code(), 429);
+    assert_eq!(error.errno().unwrap(), 107);
+    assert_eq!(error.error(), "Too Many Requests");
+    assert_eq!(error.to_string(), "Email account soft bounced");
+    let additional_fields = error.additional_fields();
+    assert_eq!(additional_fields.get("address").unwrap(), "foo@example.com");
+    let record: DeliveryProblem =
+        serde_json::from_str(additional_fields.get("problem").unwrap().as_str().unwrap()).unwrap();
+    assert_eq!(record.problem_type, ProblemType::SoftBounce);
+    assert_eq!(
+        record.created_at,
+        additional_fields.get("time").unwrap().as_u64().unwrap()
+    );
 }
 
 #[derive(Debug)]
@@ -160,25 +157,22 @@ fn check_hard_bounce() {
     let settings = create_settings(bounce_settings);
     let db = DbMockBounceHard;
     let problems = DeliveryProblems::new(&settings, db);
-    match problems.check(&"bar@example.com".parse().unwrap()) {
-        Ok(_) => assert!(false, "DeliveryProblems::check should have failed"),
-        Err(error) => {
-            assert_eq!(format!("{}", error), "Email account hard bounced");
-            let err_data = error.kind().additional_fields();
-            let address = err_data.get("address");
-            if let Some(ref address) = address {
-                assert_eq!("bar@example.com", address.as_str().unwrap());
-            } else {
-                assert!(false, "Error::address should be set");
-            }
-            let problem = err_data.get("problem");
-            assert!(problem.is_some());
-            let record: Json = serde_json::from_str(problem.unwrap().as_str().unwrap()).unwrap();
-            assert_eq!(record["problem_type"], 1);
-            assert_eq!(&record["created_at"], err_data.get("time").unwrap());
-            assert_eq!(error.kind().http_status(), Status::TooManyRequests);
-        }
-    }
+    let result = problems.check(&"bar@example.com".parse().unwrap());
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    assert_eq!(error.code(), 429);
+    assert_eq!(error.errno().unwrap(), 108);
+    assert_eq!(error.error(), "Too Many Requests");
+    assert_eq!(error.to_string(), "Email account hard bounced");
+    let additional_fields = error.additional_fields();
+    assert_eq!(additional_fields.get("address").unwrap(), "bar@example.com");
+    let record: DeliveryProblem =
+        serde_json::from_str(additional_fields.get("problem").unwrap().as_str().unwrap()).unwrap();
+    assert_eq!(record.problem_type, ProblemType::HardBounce);
+    assert_eq!(
+        record.created_at,
+        additional_fields.get("time").unwrap().as_u64().unwrap()
+    );
 }
 
 #[derive(Debug)]
@@ -212,25 +206,22 @@ fn check_complaint() {
     let settings = create_settings(bounce_settings);
     let db = DbMockComplaint;
     let problems = DeliveryProblems::new(&settings, db);
-    match problems.check(&"baz@example.com".parse().unwrap()) {
-        Ok(_) => assert!(false, "DeliveryProblems::check should have failed"),
-        Err(error) => {
-            assert_eq!(format!("{}", error), "Email account sent complaint");
-            let err_data = error.kind().additional_fields();
-            let address = err_data.get("address");
-            if let Some(ref address) = address {
-                assert_eq!("baz@example.com", address.as_str().unwrap());
-            } else {
-                assert!(false, "Error::address should be set");
-            }
-            let problem = err_data.get("problem");
-            assert!(problem.is_some());
-            let record: Json = serde_json::from_str(problem.unwrap().as_str().unwrap()).unwrap();
-            assert_eq!(record["problem_type"], 3);
-            assert_eq!(&record["created_at"], err_data.get("time").unwrap());
-            assert_eq!(error.kind().http_status(), Status::TooManyRequests);
-        }
-    }
+    let result = problems.check(&"baz@example.com".parse().unwrap());
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    assert_eq!(error.code(), 429);
+    assert_eq!(error.errno().unwrap(), 106);
+    assert_eq!(error.error(), "Too Many Requests");
+    assert_eq!(error.to_string(), "Email account sent complaint");
+    let additional_fields = error.additional_fields();
+    assert_eq!(additional_fields.get("address").unwrap(), "baz@example.com");
+    let record: DeliveryProblem =
+        serde_json::from_str(additional_fields.get("problem").unwrap().as_str().unwrap()).unwrap();
+    assert_eq!(record.problem_type, ProblemType::Complaint);
+    assert_eq!(
+        record.created_at,
+        additional_fields.get("time").unwrap().as_u64().unwrap()
+    );
 }
 
 #[derive(Debug)]
@@ -268,13 +259,14 @@ fn check_db_error() {
     let settings = create_settings(bounce_settings);
     let db = DbMockError;
     let problems = DeliveryProblems::new(&settings, db);
-    match problems.check(&"foo@example.com".parse().unwrap()) {
-        Ok(_) => assert!(false, "DeliveryProblems::check should have failed"),
-        Err(error) => {
-            assert_eq!(format!("{}", error), "wibble blee");
-            assert_eq!(error.kind().http_status(), Status::InternalServerError);
-        }
-    }
+    let result = problems.check(&"foo@example.com".parse().unwrap());
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    assert_eq!(error.code(), 500);
+    assert_eq!(error.errno().unwrap(), 109);
+    assert_eq!(error.error(), "Internal Server Error");
+    assert_eq!(error.to_string(), "wibble blee");
+    assert_eq!(error.additional_fields().len(), 0);
 }
 
 #[derive(Debug)]
@@ -394,24 +386,18 @@ fn check_bounce_with_multiple_limits() {
     let settings = create_settings(bounce_settings);
     let db = DbMockBounceWithMultipleLimits;
     let problems = DeliveryProblems::new(&settings, db);
-    match problems.check(&"foo@example.com".parse().unwrap()) {
-        Ok(_) => assert!(false, "DeliveryProblems::check should have failed"),
-        Err(error) => {
-            assert_eq!(format!("{}", error), "Email account soft bounced");
-            let err_data = error.kind().additional_fields();
-            let address = err_data.get("address");
-            if let Some(ref address) = address {
-                assert_eq!("foo@example.com", address.as_str().unwrap());
-            } else {
-                assert!(false, "Error::address should be set");
-            }
-            let problem = err_data.get("problem");
-            assert!(problem.is_some());
-            let record: Json = serde_json::from_str(problem.unwrap().as_str().unwrap()).unwrap();
-            assert_eq!(record["problem_type"], 2);
-            assert_eq!(&record["created_at"], err_data.get("time").unwrap());
-        }
-    }
+    let result = problems.check(&"foo@example.com".parse().unwrap());
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    assert_eq!(error.code(), 429);
+    assert_eq!(error.errno().unwrap(), 107);
+    assert_eq!(error.error(), "Too Many Requests");
+    assert_eq!(error.to_string(), "Email account soft bounced");
+    let additional_fields = error.additional_fields();
+    assert_eq!(additional_fields.get("address").unwrap(), "foo@example.com");
+    let record: DeliveryProblem =
+        serde_json::from_str(additional_fields.get("problem").unwrap().as_str().unwrap()).unwrap();
+    assert_eq!(record.problem_type, ProblemType::SoftBounce);
 }
 
 #[derive(Debug)]

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -64,7 +64,7 @@ impl KV for RequestMozlogFields {
 #[derive(Clone)]
 struct AppErrorFields {
     code: u16,
-    error: String,
+    error: &'static str,
     errno: Option<u16>,
     message: String,
     additional_fields: Map<String, JsonValue>,
@@ -72,15 +72,12 @@ struct AppErrorFields {
 
 impl AppErrorFields {
     pub fn from_app_error(error: &AppError) -> AppErrorFields {
-        let kind = error.kind();
-        let status = kind.http_status();
-
         AppErrorFields {
-            code: status.code,
-            error: status.reason.to_string(),
-            errno: kind.errno(),
-            message: format!("{}", error),
-            additional_fields: kind.additional_fields(),
+            code: error.code(),
+            error: error.error(),
+            errno: error.errno(),
+            message: error.to_string(),
+            additional_fields: error.additional_fields(),
         }
     }
 }

--- a/src/providers/ses/test.rs
+++ b/src/providers/ses/test.rs
@@ -83,25 +83,12 @@ fn ses_send_handles_error_response() {
         )),
         sender: "Foo Bar <a@a.com>".to_string(),
     };
-    match mock_ses.send("b@b.com", &[], None, "subject", "body", None) {
-        Ok(_) => assert!(false, "Request should have failed"),
-        Err(error) => {
-            let error = error.json();
-            assert_eq!(
-                500,
-                error["code"]
-                    .as_u64()
-                    .expect("Error code should be a number")
-            );
-            assert_eq!(
-                104,
-                error["errno"]
-                    .as_u64()
-                    .expect("Error errno should be a number")
-            );
-            assert_eq!("Internal Server Error", &error["error"]);
-            assert_eq!("Unknown(\"FREAKOUT\")", &error["message"]);
-            assert_eq!("SES", &error["name"]);
-        }
-    }
+    let result = mock_ses.send("b@b.com", &[], None, "subject", "body", None);
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    assert_eq!(error.code(), 500);
+    assert_eq!(error.errno().unwrap(), 104);
+    assert_eq!(error.error(), "Internal Server Error");
+    assert_eq!(error.to_string(), "Unknown(\"FREAKOUT\")");
+    assert_eq!(error.additional_fields().get("name").unwrap(), "SES");
 }

--- a/src/types/error/test.rs
+++ b/src/types/error/test.rs
@@ -2,52 +2,58 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 
-use super::AppErrorKind;
+use super::*;
 
 #[test]
 fn bad_request() {
-    assert_eq!(
-        format!("{}", super::bad_request().unwrap_err().kind()),
-        format!("{}", AppErrorKind::BadRequest)
-    );
+    let error: AppError = AppErrorKind::BadRequest.into();
+    assert_eq!(error.code(), 400);
+    assert_eq!(error.error(), "Bad Request");
+    assert!(error.errno().is_none());
+    assert_eq!(error.additional_fields().len(), 0);
 }
 
 #[test]
 fn not_found() {
-    assert_eq!(
-        format!("{}", super::not_found().unwrap_err().kind()),
-        format!("{}", AppErrorKind::NotFound)
-    );
+    let error: AppError = AppErrorKind::NotFound.into();
+    assert_eq!(error.code(), 404);
+    assert_eq!(error.error(), "Not Found");
+    assert!(error.errno().is_none());
+    assert_eq!(error.additional_fields().len(), 0);
 }
 
 #[test]
 fn method_not_allowed() {
-    assert_eq!(
-        format!("{}", super::method_not_allowed().unwrap_err().kind()),
-        format!("{}", AppErrorKind::MethodNotAllowed)
-    );
+    let error: AppError = AppErrorKind::MethodNotAllowed.into();
+    assert_eq!(error.code(), 405);
+    assert_eq!(error.error(), "Method Not Allowed");
+    assert!(error.errno().is_none());
+    assert_eq!(error.additional_fields().len(), 0);
 }
 
 #[test]
 fn unprocessable_entity() {
-    assert_eq!(
-        format!("{}", super::unprocessable_entity().unwrap_err().kind()),
-        format!("{}", AppErrorKind::UnprocessableEntity)
-    );
+    let error: AppError = AppErrorKind::UnprocessableEntity.into();
+    assert_eq!(error.code(), 422);
+    assert_eq!(error.error(), "Unprocessable Entity");
+    assert!(error.errno().is_none());
+    assert_eq!(error.additional_fields().len(), 0);
 }
 
 #[test]
 fn too_many_requests() {
-    assert_eq!(
-        format!("{}", super::too_many_requests().unwrap_err().kind()),
-        format!("{}", AppErrorKind::TooManyRequests)
-    );
+    let error: AppError = AppErrorKind::TooManyRequests.into();
+    assert_eq!(error.code(), 429);
+    assert_eq!(error.error(), "Too Many Requests");
+    assert!(error.errno().is_none());
+    assert_eq!(error.additional_fields().len(), 0);
 }
 
 #[test]
 fn internal_server_error() {
-    assert_eq!(
-        format!("{}", super::internal_server_error().unwrap_err().kind()),
-        format!("{}", AppErrorKind::InternalServerError)
-    );
+    let error: AppError = AppErrorKind::InternalServerError.into();
+    assert_eq!(error.code(), 500);
+    assert_eq!(error.error(), "Internal Server Error");
+    assert!(error.errno().is_none());
+    assert_eq!(error.additional_fields().len(), 0);
 }


### PR DESCRIPTION
Related to #210.

There was a minor violation of the law of Demeter in our `AppError` struct, where it was directly exposing its inner `AppErrorKind` to callers. Not a huge deal, but it meant that any changes made to the inner structure would leak out and require corresponding changes to the consuming code (and I am planning some of those inner changes as part of issue #210). Better to expose just the parts that are necessary via its own API.

At the same time, I opted to replace the home-baked `AppError::json()` method with a more conventional `impl Serialize`, because it's less astonishing and just as easy to use with `serde_json::to_string`.

@mozilla/fxa-devs r?