### PR TITLE
feat(types): ignore display name part when parsing email addresses

### DIFF
--- a/src/types/email_address/mod.rs
+++ b/src/types/email_address/mod.rs
@@ -48,11 +48,25 @@ impl FromStr for EmailAddress {
     type Err = DeserializeError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
-        if validate::email_address(&value) {
+        let mut value = value;
+
+        if let Some(opening_index) = value.find('<') {
+            if let Some(closing_index) = value.rfind('>') {
+                if opening_index < closing_index {
+                    if let Some(unwrapped_value) = value.get(opening_index + 1..closing_index) {
+                        value = unwrapped_value;
+                    }
+                }
+            }
+        }
+
+        value = value.trim();
+
+        if validate::email_address(value) {
             Ok(EmailAddress(value.to_lowercase()))
         } else {
             Err(DeserializeError::invalid_value(
-                Unexpected::Str(&value),
+                Unexpected::Str(value),
                 &"email address",
             ))
         }

--- a/src/types/email_address/test.rs
+++ b/src/types/email_address/test.rs
@@ -12,35 +12,61 @@ use super::*;
 fn parse() {
     let result = "foo@example.com".parse::<EmailAddress>();
     assert!(result.is_ok());
-    match result {
-        Ok(email_address) => {
-            assert_eq!(email_address, EmailAddress(String::from("foo@example.com")));
-            assert_eq!(email_address.as_ref(), "foo@example.com");
-            assert_eq!(email_address.to_string(), "foo@example.com");
-        }
-        _ => {}
-    }
+    let email_address = result.unwrap();
+    assert_eq!(email_address, EmailAddress(String::from("foo@example.com")));
+    assert_eq!(email_address.as_ref(), "foo@example.com");
+    assert_eq!(email_address.to_string(), "foo@example.com");
+}
 
+#[test]
+fn parse_invalid() {
     let result = "foo@".parse::<EmailAddress>();
     assert!(result.is_err());
-    match result {
-        Err(error) => {
-            assert_eq!(
-                error.description(),
-                "invalid value: string \"foo@\", expected email address"
-            );
-        }
-        _ => {}
-    }
+    assert_eq!(
+        result.unwrap_err().description(),
+        "invalid value: string \"foo@\", expected email address"
+    );
+}
 
+#[test]
+fn parse_uppercase() {
     let result = "BAR@EXAMPLE.COM".parse::<EmailAddress>();
     assert!(result.is_ok());
-    match result {
-        Ok(email_address) => {
-            assert_eq!(email_address.as_ref(), "bar@example.com");
-        }
-        _ => {}
-    }
+    assert_eq!(result.unwrap().as_ref(), "bar@example.com");
+}
+
+#[test]
+fn parse_with_unicode() {
+    let result = "٢fooΔ@example.com".parse::<EmailAddress>();
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().as_ref(), "٢fooδ@example.com");
+}
+
+#[test]
+fn parse_with_whitespace() {
+    let result = "  foo@example.com  ".parse::<EmailAddress>();
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().as_ref(), "foo@example.com");
+}
+
+#[test]
+fn parse_with_display_name() {
+    let result = "Foo Bar <baz@example.com>".parse::<EmailAddress>();
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().as_ref(), "baz@example.com");
+}
+
+#[test]
+fn parse_with_display_name_and_whitespace() {
+    let result = "< wibble@example.com >".parse::<EmailAddress>();
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap().as_ref(), "wibble@example.com");
+}
+
+#[test]
+fn parse_with_invalid_display_name() {
+    let result = "Foo Bar >baz@example.com<".parse::<EmailAddress>();
+    assert!(result.is_err());
 }
 
 #[test]


### PR DESCRIPTION
Fixes #201.

Email addresses that we receive from bounce, complaint and delivery notifications may not be identical matches to what we set on messages. We already did some normalization by lower-casing the address when parsing. This change extends that normalization process by trimming whitespace and unwrapping the address part if it has been wrapped in angle bracket delimiters to separate it from the display name. This matches the [behaviour of the auth server](https://github.com/mozilla/fxa-auth-server/blob/050a8a646304313502a31e38cbfffd6b1eabf6cf/lib/email/bounces.js#L65-L87).

@mozilla/fxa-devs r?