### PR TITLE
fix(settings): fix panic when sentry is disabled

### DIFF
--- a/src/bin/queues.rs
+++ b/src/bin/queues.rs
@@ -61,12 +61,12 @@ type LoopResult = Box<Future<Item = Loop<usize, usize>, Error = AppError>>;
 
 fn main() {
     let sentry_dsn = if let Some(ref sentry) = SETTINGS.sentry {
-        &sentry.dsn.0
+        Some(sentry.dsn.0.parse().expect("settings.sentry.dsn error"))
     } else {
-        ""
+        None
     };
     let sentry = sentry::init(sentry::ClientOptions {
-        dsn: Some(sentry_dsn.parse().expect("settings.sentry.dsn error")),
+        dsn: sentry_dsn,
         release: sentry_crate_release!(),
         ..Default::default()
     });

--- a/src/bin/service.rs
+++ b/src/bin/service.rs
@@ -36,12 +36,12 @@ fn main() {
     let settings = Settings::new().expect("Settings::new error");
 
     let sentry_dsn = if let Some(ref sentry) = settings.sentry {
-        sentry.dsn.0.clone()
+        Some(sentry.dsn.0.parse().expect("settings.sentry.dsn error"))
     } else {
-        "".to_owned()
+        None
     };
     let sentry = sentry::init(sentry::ClientOptions {
-        dsn: Some(sentry_dsn.parse().expect("settings.sentry.dsn error")),
+        dsn: sentry_dsn,
         release: sentry_crate_release!(),
         ..Default::default()
     });


### PR DESCRIPTION
I'm a fool. Yesterday, when I did #230, I only tested it with Sentry enabled. As soon as I ran the code with Sentry disabled this morning, it crashed on startup because the empty string is not a valid Sentry DSN. This change fixes it by only attempting to parse the DSN if Sentry is enabled. 😊

@mozilla/fxa-devs r?