### PR TITLE
fix(ses): ensure html part gets charset=utf-8 content type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: rust
 services:
   - redis-server
 cache: cargo
-branches:
-  only:
-    - master
 before_script:
   - rustup component add rustfmt-preview
 script:

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -74,7 +74,7 @@ fn build_multipart_mime<'a>(
         body = body.multipart(
             MultiPart::related().singlepart(
                 SinglePart::base64()
-                    .header(ContentType::html())
+                    .header(ContentType("text/html; charset=utf-8".parse()?))
                     .body(body_html),
             ),
         );

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -87,6 +87,7 @@ fn build_multipart_mime<'a>(
 fn set_custom_header(message: MessageBuilder, name: &str, value: &str) -> MessageBuilder {
     let lowercase_name = name.to_lowercase();
     match lowercase_name.as_str() {
+        "content-language" => message.header(ContentLanguage::new(value.to_owned())),
         "x-device-id" => message.header(DeviceId::new(value.to_owned())),
         "x-email-sender" => message.header(EmailSender::new(value.to_owned())),
         "x-email-service" => message.header(EmailService::new(value.to_owned())),

--- a/src/providers/test.rs
+++ b/src/providers/test.rs
@@ -102,7 +102,7 @@ fn build_mime_with_body_html() {
     assert_eq!("Content-Type: text/plain; charset=utf-8", &message[11]);
     assert_eq!("body", &message[13]);
     assert_eq!("Content-Transfer-Encoding: base64", &message[18]);
-    assert_eq!("Content-Type: text/html", &message[19]);
+    assert_eq!("Content-Type: text/html; charset=utf-8", &message[19]);
     assert_eq!("PHA+Ym9keTwvcD4=", &message[21]);
 }
 

--- a/src/providers/test.rs
+++ b/src/providers/test.rs
@@ -34,11 +34,14 @@ fn build_mime_without_optional_data() {
 
 #[test]
 fn build_mime_with_cc_headers() {
+    let mut headers = HashMap::new();
+    headers.insert("Content-Language".to_owned(), "en-gb".to_owned());
+    headers.insert("x-verify-code".to_owned(), "wibble".to_owned());
     let message = build_multipart_mime(
         "a@a.com",
         "b@b.com",
         &["c@c.com", "d@d.com"],
-        None,
+        Some(&headers),
         "subject",
         "body",
         None,
@@ -54,9 +57,15 @@ fn build_mime_with_cc_headers() {
     assert_eq!("Subject: subject", &message[3]);
     assert_eq!("MIME-Version: 1.0", &message[4]);
     assert_eq!("Cc: c@c.com, d@d.com", &message[5]);
-    assert_eq!("Content-Transfer-Encoding: quoted-printable", &message[12]);
-    assert_eq!("Content-Type: text/plain; charset=utf-8", &message[13]);
-    assert_eq!("body", &message[15]);
+    if message[6] == "Content-Language: en-gb" {
+        assert_eq!("X-Verify-Code: wibble", &message[7]);
+    } else {
+        assert_eq!("X-Verify-Code: wibble", &message[6]);
+        assert_eq!("Content-Language: en-gb", &message[7]);
+    }
+    assert_eq!("Content-Transfer-Encoding: quoted-printable", &message[14]);
+    assert_eq!("Content-Type: text/plain; charset=utf-8", &message[15]);
+    assert_eq!("body", &message[17]);
 }
 
 #[test]

--- a/src/providers/test.rs
+++ b/src/providers/test.rs
@@ -8,19 +8,28 @@ use super::*;
 
 #[test]
 fn build_mime_without_optional_data() {
-    let message =
-        build_multipart_mime("a@a.com", "b@b.com", &[], None, "subject", "body", None).unwrap();
+    let message = build_multipart_mime(
+        "Wibble Blee <a@a.com>",
+        "b@b.com",
+        &[],
+        None,
+        "subject",
+        "body",
+        None,
+    )
+    .unwrap();
     let message: Vec<String> = format!("{}", message)
         .split("\r\n")
         .map(|s| s.to_owned())
         .collect();
-    assert_eq!("From: a@a.com", &message[0]);
-    assert_eq!("To: b@b.com", &message[1]);
-    assert_eq!("Subject: subject", &message[2]);
-    assert_eq!("MIME-Version: 1.0", &message[3]);
-    assert_eq!("Content-Transfer-Encoding: quoted-printable", &message[10]);
-    assert_eq!("Content-Type: text/plain; charset=utf-8", &message[11]);
-    assert_eq!("body", &message[13]);
+    assert_eq!("Sender: Wibble Blee <a@a.com>", &message[0]);
+    assert_eq!("From: Wibble Blee <a@a.com>", &message[1]);
+    assert_eq!("To: b@b.com", &message[2]);
+    assert_eq!("Subject: subject", &message[3]);
+    assert_eq!("MIME-Version: 1.0", &message[4]);
+    assert_eq!("Content-Transfer-Encoding: quoted-printable", &message[11]);
+    assert_eq!("Content-Type: text/plain; charset=utf-8", &message[12]);
+    assert_eq!("body", &message[14]);
 }
 
 #[test]
@@ -39,14 +48,15 @@ fn build_mime_with_cc_headers() {
         .split("\r\n")
         .map(|s| s.to_owned())
         .collect();
-    assert_eq!("From: a@a.com", &message[0]);
-    assert_eq!("To: b@b.com", &message[1]);
-    assert_eq!("Subject: subject", &message[2]);
-    assert_eq!("MIME-Version: 1.0", &message[3]);
-    assert_eq!("Cc: c@c.com, d@d.com", &message[4]);
-    assert_eq!("Content-Transfer-Encoding: quoted-printable", &message[11]);
-    assert_eq!("Content-Type: text/plain; charset=utf-8", &message[12]);
-    assert_eq!("body", &message[14]);
+    assert_eq!("Sender: a@a.com", &message[0]);
+    assert_eq!("From: a@a.com", &message[1]);
+    assert_eq!("To: b@b.com", &message[2]);
+    assert_eq!("Subject: subject", &message[3]);
+    assert_eq!("MIME-Version: 1.0", &message[4]);
+    assert_eq!("Cc: c@c.com, d@d.com", &message[5]);
+    assert_eq!("Content-Transfer-Encoding: quoted-printable", &message[12]);
+    assert_eq!("Content-Type: text/plain; charset=utf-8", &message[13]);
+    assert_eq!("body", &message[15]);
 }
 
 #[test]
@@ -68,14 +78,15 @@ fn build_mime_with_custom_headers() {
         .split("\r\n")
         .map(|s| s.to_owned())
         .collect();
-    assert_eq!("From: a@a.com", &message[0]);
-    assert_eq!("To: b@b.com", &message[1]);
-    assert_eq!("Subject: subject", &message[2]);
-    assert_eq!("MIME-Version: 1.0", &message[3]);
-    assert_eq!("X-Device-Id: baz", &message[4]);
-    assert_eq!("Content-Transfer-Encoding: quoted-printable", &message[11]);
-    assert_eq!("Content-Type: text/plain; charset=utf-8", &message[12]);
-    assert_eq!("body", &message[14]);
+    assert_eq!("Sender: a@a.com", &message[0]);
+    assert_eq!("From: a@a.com", &message[1]);
+    assert_eq!("To: b@b.com", &message[2]);
+    assert_eq!("Subject: subject", &message[3]);
+    assert_eq!("MIME-Version: 1.0", &message[4]);
+    assert_eq!("X-Device-Id: baz", &message[5]);
+    assert_eq!("Content-Transfer-Encoding: quoted-printable", &message[12]);
+    assert_eq!("Content-Type: text/plain; charset=utf-8", &message[13]);
+    assert_eq!("body", &message[15]);
 }
 
 #[test]
@@ -94,16 +105,17 @@ fn build_mime_with_body_html() {
         .split("\r\n")
         .map(|s| s.to_owned())
         .collect();
-    assert_eq!("From: a@a.com", &message[0]);
-    assert_eq!("To: b@b.com", &message[1]);
-    assert_eq!("Subject: subject", &message[2]);
-    assert_eq!("MIME-Version: 1.0", &message[3]);
-    assert_eq!("Content-Transfer-Encoding: quoted-printable", &message[10]);
-    assert_eq!("Content-Type: text/plain; charset=utf-8", &message[11]);
-    assert_eq!("body", &message[13]);
-    assert_eq!("Content-Transfer-Encoding: base64", &message[18]);
-    assert_eq!("Content-Type: text/html; charset=utf-8", &message[19]);
-    assert_eq!("PHA+Ym9keTwvcD4=", &message[21]);
+    assert_eq!("Sender: a@a.com", &message[0]);
+    assert_eq!("From: a@a.com", &message[1]);
+    assert_eq!("To: b@b.com", &message[2]);
+    assert_eq!("Subject: subject", &message[3]);
+    assert_eq!("MIME-Version: 1.0", &message[4]);
+    assert_eq!("Content-Transfer-Encoding: quoted-printable", &message[11]);
+    assert_eq!("Content-Type: text/plain; charset=utf-8", &message[12]);
+    assert_eq!("body", &message[14]);
+    assert_eq!("Content-Transfer-Encoding: base64", &message[19]);
+    assert_eq!("Content-Type: text/html; charset=utf-8", &message[20]);
+    assert_eq!("PHA+Ym9keTwvcD4=", &message[22]);
 }
 
 #[test]

--- a/src/types/error/mod.rs
+++ b/src/types/error/mod.rs
@@ -12,6 +12,7 @@ use std::{
 
 use failure::{Backtrace, Context, Fail};
 use hmac::crypto_mac::InvalidKeyLength;
+use hyperx::mime::FromStrError;
 use lettre::smtp::error::Error as SmtpError;
 use lettre_email::error::Error as EmailError;
 use redis::RedisError;
@@ -252,6 +253,7 @@ macro_rules! to_internal_error {
 }
 
 to_internal_error!(EmailError);
+to_internal_error!(FromStrError);
 to_internal_error!(InvalidKeyLength);
 to_internal_error!(JsonError);
 to_internal_error!(RedisError);

--- a/src/types/headers/mod.rs
+++ b/src/types/headers/mod.rs
@@ -73,6 +73,7 @@ macro_rules! custom_header {
     };
 }
 
+custom_header!(ContentLanguage, "Content-Language");
 custom_header!(DeviceId, "X-Device-Id");
 custom_header!(EmailSender, "X-Email-Sender");
 custom_header!(EmailService, "X-Email-Service");

--- a/src/types/headers/test.rs
+++ b/src/types/headers/test.rs
@@ -5,6 +5,13 @@
 use super::*;
 
 #[test]
+fn content_language() {
+    let header = ContentLanguage::new("en-gb".to_owned());
+    assert_eq!(header.to_string(), "en-gb");
+    assert_eq!(ContentLanguage::header_name(), "Content-Language");
+}
+
+#[test]
 fn device_id() {
     let header = DeviceId::new("wibble".to_owned());
     assert_eq!(header.to_string(), "wibble");


### PR DESCRIPTION
Fixes #239.

The missing `charset` in the `Content-Type` header caused train 124 to fail. I could have patched it in 124 but it feels like we're close enough to train 125 to patch it there instead now (and I don't even know if there's ops bandwidth to test it out in 124 again anyway).

I've also added the `Sender` header, although I don't *think* its absence was causing problems. The spec seems pretty clear that it falls back to the value of `From` by default, but email servers are a capricious species so better to be explicit.

The `Content-Language` header can only be patched in the auth server (patch incoming). The `Content-Transfer-Encoding` header is by design.

@mozilla/fxa-devs r?