### PR TITLE
fix(sentry): stop passing 4xx errors to Sentry

### DIFF
--- a/src/types/error/mod.rs
+++ b/src/types/error/mod.rs
@@ -87,10 +87,16 @@ impl Fail for AppError {
 
 impl From<AppErrorKind> for AppError {
     fn from(kind: AppErrorKind) -> AppError {
+        let capture_in_sentry = kind.http_status() == Status::InternalServerError;
+
         let error = AppError {
             inner: Context::new(kind).into(),
         };
-        sentry::integrations::failure::capture_fail(&error);
+
+        if capture_in_sentry {
+            sentry::integrations::failure::capture_fail(&error);
+        }
+
         error
     }
 }


### PR DESCRIPTION
Fixes #244.

I made Sentry too noisy when I did #230. This ensures that only `500` errors show up there.

Opened against train 125 for a point release.

@mozilla/fxa-devs r?