### PR TITLE
refactor(settings): promote Env to an enum from a wrapped string

### DIFF
--- a/src/settings/test.rs
+++ b/src/settings/test.rs
@@ -128,7 +128,11 @@ fn env_vars_take_precedence() {
                 }
             };
             let bounce_limits_enabled = !settings.bouncelimits.enabled;
-            let current_env = Env(String::from("test"));
+            let current_env = if settings.env == Env::Dev {
+                Env::Prod
+            } else {
+                Env::Dev
+            };
             let hmac_key = String::from("something else");
             let provider = Provider {
                 default: if settings.provider.default == ProviderType::Ses {
@@ -210,7 +214,7 @@ fn env_vars_take_precedence() {
                 &bounce_limits_enabled.to_string(),
             );
             env::set_var("FXA_EMAIL_HMACKEY", &hmac_key.to_string());
-            env::set_var("FXA_EMAIL_ENV", &current_env.0);
+            env::set_var("FXA_EMAIL_ENV", current_env.as_ref());
             env::set_var("FXA_EMAIL_LOG_LEVEL", &log.level.0);
             env::set_var("FXA_EMAIL_LOG_FORMAT", &log.format.0);
             env::set_var("FXA_EMAIL_PROVIDER_DEFAULT", provider.default.as_ref());
@@ -317,7 +321,7 @@ fn default_env() {
     let _clean_env = CleanEnvironment::new(vec!["FXA_EMAIL_ENV"]);
 
     match Settings::new() {
-        Ok(settings) => assert_eq!(settings.env, Env("dev".to_string())),
+        Ok(settings) => assert_eq!(settings.env, Env::Dev),
         Err(_error) => assert!(false, "Settings::new shouldn't have failed"),
     }
 }

--- a/src/types/env/mod.rs
+++ b/src/types/env/mod.rs
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 
-//! Email provider type.
+//! Environment type.
 
 #[cfg(test)]
 mod test;
@@ -11,16 +11,14 @@ use serde::de::Error;
 
 use types::error::{AppError, AppErrorKind};
 
-enum_boilerplate!(Provider ("env", InvalidPayload) {
-    Mock => "mock",
-    Sendgrid => "sendgrid",
-    Ses => "ses",
-    Smtp => "smtp",
-    SocketLabs => "socketlabs",
+enum_boilerplate!(Env ("env", InvalidEnv) {
+    Dev => "dev",
+    Prod => "production",
+    Test => "test",
 });
 
-impl Default for Provider {
+impl Default for Env {
     fn default() -> Self {
-        Provider::Ses
+        Env::Dev
     }
 }

--- a/src/types/env/test.rs
+++ b/src/types/env/test.rs
@@ -1,0 +1,30 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::convert::TryFrom;
+
+use super::*;
+
+#[test]
+fn try_from() {
+    let result: Result<Env, AppError> = TryFrom::try_from("dev");
+    assert!(result.is_ok());
+
+    let result: Result<Env, AppError> = TryFrom::try_from("production");
+    assert!(result.is_ok());
+
+    let result: Result<Env, AppError> = TryFrom::try_from("test");
+    assert!(result.is_ok());
+
+    let result: Result<Env, AppError> = TryFrom::try_from("prod");
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().to_string(), "Invalid environment: prod");
+}
+
+#[test]
+fn as_ref() {
+    assert_eq!(Env::Dev.as_ref(), "dev");
+    assert_eq!(Env::Prod.as_ref(), "production");
+    assert_eq!(Env::Test.as_ref(), "test");
+}

--- a/src/types/error/mod.rs
+++ b/src/types/error/mod.rs
@@ -188,6 +188,9 @@ pub enum AppErrorKind {
         time: u64,
         problem: DeliveryProblem,
     },
+
+    #[fail(display = "Invalid environment: {}", _0)]
+    InvalidEnv(String),
 }
 
 impl AppErrorKind {
@@ -213,6 +216,7 @@ impl AppErrorKind {
             AppErrorKind::Complaint { .. } => Some(106),
             AppErrorKind::SoftBounce { .. } => Some(107),
             AppErrorKind::HardBounce { .. } => Some(108),
+            AppErrorKind::InvalidEnv { .. } => Some(109),
         }
     }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -6,8 +6,68 @@
 //! for modules that implement
 //! miscellaneous generally-used types.
 
+macro_rules! enum_boilerplate {
+    ($name:ident ($description:expr, $error:ident) {
+        $($variant:ident => $serialization:expr,)+
+    }) => {
+        #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+        pub enum $name {
+            $($variant,
+            )+
+        }
+
+        impl AsRef<str> for $name {
+            fn as_ref(&self) -> &str {
+                match *self {
+                    $($name::$variant => $serialization,
+                    )+
+                }
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                write!(formatter, "{}", self.as_ref())
+            }
+        }
+
+        impl<'d> serde::de::Deserialize<'d> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::de::Deserializer<'d>,
+            {
+                let value: String = serde::de::Deserialize::deserialize(deserializer)?;
+                std::convert::TryFrom::try_from(value.as_str())
+                    .map_err(|_| D::Error::invalid_value(serde::de::Unexpected::Str(&value), &$description))
+            }
+        }
+
+        impl serde::ser::Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::ser::Serializer,
+            {
+                serializer.serialize_str(self.as_ref())
+            }
+        }
+
+        impl<'v> std::convert::TryFrom<&'v str> for $name {
+            type Error = AppError;
+
+            fn try_from(value: &str) -> Result<Self, Self::Error> {
+                match value {
+                    $($serialization => Ok($name::$variant),
+                    )+
+                    _ => Err(AppErrorKind::$error(value.to_owned()))?,
+                }
+            }
+        }
+    }
+}
+
 pub mod duration;
 pub mod email_address;
+pub mod env;
 pub mod error;
 pub mod headers;
 pub mod provider;

--- a/src/types/provider/test.rs
+++ b/src/types/provider/test.rs
@@ -2,36 +2,35 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 
+use std::convert::TryFrom;
+
 use super::*;
 
 #[test]
 fn try_from() {
-    match Provider::try_from("mock") {
-        Ok(provider) => assert_eq!(provider, Provider::Mock),
-        Err(error) => assert!(false, error.to_string()),
-    }
-    match Provider::try_from("sendgrid") {
-        Ok(provider) => assert_eq!(provider, Provider::Sendgrid),
-        Err(error) => assert!(false, error.to_string()),
-    }
-    match Provider::try_from("ses") {
-        Ok(provider) => assert_eq!(provider, Provider::Ses),
-        Err(error) => assert!(false, error.to_string()),
-    }
-    match Provider::try_from("smtp") {
-        Ok(provider) => assert_eq!(provider, Provider::Smtp),
-        Err(error) => assert!(false, error.to_string()),
-    }
-    match Provider::try_from("socketlabs") {
-        Ok(provider) => assert_eq!(provider, Provider::SocketLabs),
-        Err(error) => assert!(false, error.to_string()),
-    }
-    match Provider::try_from("wibble") {
-        Ok(_) => assert!(false, "Provider::try_from should have failed"),
-        Err(error) => {
-            assert_eq!(error.to_string(), "Invalid payload: provider `wibble`");
-        }
-    }
+    let result: Result<Provider, AppError> = TryFrom::try_from("mock");
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), Provider::Mock);
+
+    let result: Result<Provider, AppError> = TryFrom::try_from("sendgrid");
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), Provider::Sendgrid);
+
+    let result: Result<Provider, AppError> = TryFrom::try_from("ses");
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), Provider::Ses);
+
+    let result: Result<Provider, AppError> = TryFrom::try_from("smtp");
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), Provider::Smtp);
+
+    let result: Result<Provider, AppError> = TryFrom::try_from("socketlabs");
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), Provider::SocketLabs);
+
+    let result: Result<Provider, AppError> = TryFrom::try_from("wibble");
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().to_string(), "Invalid payload: wibble");
 }
 
 #[test]

--- a/src/types/validate/mod.rs
+++ b/src/types/validate/mod.rs
@@ -28,7 +28,6 @@ lazy_static! {
     static ref EMAIL_ADDRESS_FORMAT: Regex = Regex::new(
         r"^[a-zA-Z0-9.\pL\pN!#$%&’*+/=?^_`{|}~-]{1,64}@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,253}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,253}[a-zA-Z0-9])?)+$"
     ).unwrap();
-    static ref ENV: Regex = Regex::new(r"^(?:dev|staging|production|test)$").unwrap();
     static ref HOST_FORMAT: Regex = Regex::new(r"^[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*$").unwrap();
     static ref LOGGING_LEVEL: Regex = Regex::new(r"^(?:normal|debug|critical|off)$").unwrap();
     static ref LOGGING_FORMAT: Regex = Regex::new(r"^(?:mozlog|pretty|null)$").unwrap();
@@ -64,11 +63,6 @@ pub fn base_uri(value: &str) -> bool {
 /// Validate an email address.
 pub fn email_address(value: &str) -> bool {
     value.len() < 254 && EMAIL_ADDRESS_FORMAT.is_match(value)
-}
-
-/// Validate env.
-pub fn env(value: &str) -> bool {
-    ENV.is_match(value)
 }
 
 /// Validate a host name or IP address.

--- a/src/types/validate/test.rs
+++ b/src/types/validate/test.rs
@@ -128,15 +128,6 @@ fn invalid_email_address() {
 }
 
 #[test]
-fn env() {
-    assert!(validate::env("test"));
-    assert!(validate::env("dev"));
-    assert!(validate::env("staging"));
-    assert!(validate::env("production"));
-    assert_eq!(false, validate::env("something else"));
-}
-
-#[test]
 fn host() {
     assert!(validate::host("foo"));
     assert!(validate::host("foo.bar"));


### PR DESCRIPTION
Related to #216.

There are a bunch of string settings that should be enums. As a first step to fixing that, here I pull out some common enum boilerplate to an `enum_boilerplate!` macro and use it to implement `Env`, which was previously a wrapped string, and `Provider`, which was already an enum.

I didn't try to fix any of the other settings yet because I thought the macro might be a contentious change. If this gets the green light, it will be straightforward to mop up the remaining settings using the same macro.

@mozilla/fxa-devs r?