### PR TITLE
chore(build): lower the debug level to decrease binary size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/bin/queues.rs"
 
 [profile.release]
 # Include debug symbols to make Sentry errors richer
-debug = true
+debug = 1
 
 [dependencies]
 base64 = ">=0.6.0"


### PR DESCRIPTION
In https://github.com/mozilla-services/syncstorage-rs/pull/91#discussion_r235500761, it was pointed out that `debug = true` is the maximum debug info setting and Sentry can still pull out line numbers if we use a lower level instead. Ergo, `debug = 1`.

@mozilla/fxa-devs r?