### PR TITLE
refactor(settings): rename `BounceLimit(s)` to `DeliveryProblemLimit(s)`

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -5,7 +5,7 @@
   "aws": {
     "region": "us-west-2"
   },
-  "bouncelimits": {
+  "deliveryproblemlimits": {
     "enabled": true,
     "complaint": [
       { "period": "day", "limit": 0 },

--- a/src/api/healthcheck/test.rs
+++ b/src/api/healthcheck/test.rs
@@ -79,11 +79,11 @@ fn successful_version() {
     assert_eq!(
         body,
         json!({
-        "build": "TBD",
-        "commit": "TBD",
-        "source": "https://github.com/mozilla/fxa-email-service",
-        "version": "TBD"
-    })
+            "build": "TBD",
+            "commit": "TBD",
+            "source": "https://github.com/mozilla/fxa-email-service",
+            "version": "TBD"
+        })
         .to_string()
     );
     assert_eq!(response.status(), Status::Ok);

--- a/src/db/delivery_problems/test.rs
+++ b/src/db/delivery_problems/test.rs
@@ -47,9 +47,10 @@ fn check_no_bounces() {
     }
 }
 
-fn create_settings(bounce_limits: Json) -> Settings {
+fn create_settings(delivery_problem_limits: Json) -> Settings {
     let mut settings = Settings::default();
-    settings.bouncelimits = serde_json::from_value(bounce_limits).expect("JSON error");
+    settings.deliveryproblemlimits =
+        serde_json::from_value(delivery_problem_limits).expect("JSON error");
     settings.redis.host = Host(String::from("127.0.0.1"));
     settings.redis.port = 6379;
     settings

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -124,7 +124,7 @@ pub struct AwsKeys {
 
 /// A definition object for a bounce/complaint limit.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct BounceLimit {
+pub struct DeliveryProblemLimit {
     /// The time period
     /// within which to limit bounces/complaints.
     pub period: Duration,
@@ -137,21 +137,21 @@ pub struct BounceLimit {
 /// Controls the thresholds and behaviour
 /// for bounce and complaint reports.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
-pub struct BounceLimits {
-    /// Controls whether to enable bounce limits.
+pub struct DeliveryProblemLimits {
+    /// Controls whether to enable delivery problem limits.
     /// If set to `false`,
     /// bounce and complaint records in the database
     /// are ignored.
     pub enabled: bool,
 
     /// Limits for complaints/spam reports.
-    pub complaint: Vec<BounceLimit>,
+    pub complaint: Vec<DeliveryProblemLimit>,
 
     /// Limits for hard (permanent) bounces.
-    pub hard: Vec<BounceLimit>,
+    pub hard: Vec<DeliveryProblemLimit>,
 
     /// Limits for soft (transient) bounces.
-    pub soft: Vec<BounceLimit>,
+    pub soft: Vec<DeliveryProblemLimit>,
 }
 
 /// Settings for logging.
@@ -303,10 +303,10 @@ pub struct Settings {
 
     /// Controls the thresholds and behaviour
     /// for bounce and complaint reports.
-    /// If bounce limits are enabled,
+    /// If delivery problem limits are enabled,
     /// emails sent to offending addresses
     /// will fail with a `429` error.
-    pub bouncelimits: BounceLimits,
+    pub deliveryproblemlimits: DeliveryProblemLimits,
 
     /// The env sets which environment we are in.
     /// It defaults to `dev` if not set.

--- a/src/settings/test.rs
+++ b/src/settings/test.rs
@@ -64,7 +64,7 @@ fn env_vars_take_precedence() {
         "FXA_EMAIL_AWS_SQSURLS_COMPLAINT",
         "FXA_EMAIL_AWS_SQSURLS_DELIVERY",
         "FXA_EMAIL_AWS_SQSURLS_NOTIFICATION",
-        "FXA_EMAIL_BOUNCELIMITS_ENABLED",
+        "FXA_EMAIL_DELIVERYPROBLEMLIMITS_ENABLED",
         "FXA_EMAIL_ENV",
         "FXA_EMAIL_LOG_LEVEL",
         "FXA_EMAIL_LOG_FORMAT",
@@ -127,7 +127,7 @@ fn env_vars_take_precedence() {
                     )),
                 }
             };
-            let bounce_limits_enabled = !settings.bouncelimits.enabled;
+            let delivery_problem_limits_enabled = !settings.deliveryproblemlimits.enabled;
             let current_env = if settings.env == Env::Dev {
                 Env::Prod
             } else {
@@ -210,8 +210,8 @@ fn env_vars_take_precedence() {
                 &aws_sqs_urls.notification.0,
             );
             env::set_var(
-                "FXA_EMAIL_BOUNCELIMITS_ENABLED",
-                &bounce_limits_enabled.to_string(),
+                "FXA_EMAIL_DELIVERYPROBLEMLIMITS_ENABLED",
+                &delivery_problem_limits_enabled.to_string(),
             );
             env::set_var("FXA_EMAIL_HMACKEY", &hmac_key.to_string());
             env::set_var("FXA_EMAIL_ENV", current_env.as_ref());
@@ -246,7 +246,10 @@ fn env_vars_take_precedence() {
                 Ok(env_settings) => {
                     assert_eq!(env_settings.authdb.baseuri, BaseUri(auth_db_base_uri));
                     assert_eq!(env_settings.aws.region, AwsRegion(aws_region.to_string()));
-                    assert_eq!(env_settings.bouncelimits.enabled, bounce_limits_enabled);
+                    assert_eq!(
+                        env_settings.deliveryproblemlimits.enabled,
+                        delivery_problem_limits_enabled
+                    );
                     assert_eq!(env_settings.env, current_env);
                     assert_eq!(env_settings.hmackey, hmac_key);
                     assert_eq!(env_settings.log.level, log.level);
@@ -475,9 +478,9 @@ fn invalid_aws_notification_queue_url() {
 }
 
 #[test]
-fn invalid_bouncelimits_enabled() {
-    let _clean_env = CleanEnvironment::new(vec!["FXA_EMAIL_BOUNCELIMITS_ENABLED"]);
-    env::set_var("FXA_EMAIL_BOUNCELIMITS_ENABLED", "falsey");
+fn invalid_deliveryproblemslimits_enabled() {
+    let _clean_env = CleanEnvironment::new(vec!["FXA_EMAIL_DELIVERYPROBLEMLIMITS_ENABLED"]);
+    env::set_var("FXA_EMAIL_DELIVERYPROBLEMLIMITS_ENABLED", "falsey");
 
     match Settings::new() {
         Ok(_settings) => assert!(false, "Settings::new should have failed"),


### PR DESCRIPTION
This PR renames `BounceLimit(s)` to `DeliveryProblemLimit(s)`, which better describes what the struct is storing since it can contain delivery bounces and complaints.

Fixes #217 