### PR TITLE
refactor(settings): promote LogFormat and LogLevel to enums

### DIFF
--- a/scripts/test_standalone.sh
+++ b/scripts/test_standalone.sh
@@ -2,8 +2,8 @@
 
 export RUST_BACKTRACE=1
 
-if [ -z "$FXA_EMAIL_LOG_FORMAT" ]; then
-  export FXA_EMAIL_LOG_FORMAT=null
+if [ -z "$FXA_EMAIL_LOG_LEVEL" ]; then
+  export FXA_EMAIL_LOG_LEVEL=off
 fi
 
 cargo test -- --test-threads=1

--- a/scripts/test_with_authdb.sh
+++ b/scripts/test_with_authdb.sh
@@ -17,9 +17,10 @@ fi
 
 sleep 2
 
-if [ -z "$FXA_EMAIL_LOG_FORMAT" ]; then
-  export FXA_EMAIL_LOG_FORMAT=null
+if [ -z "$FXA_EMAIL_LOG_LEVEL" ]; then
+  export FXA_EMAIL_LOG_LEVEL=off
 fi
 
 export RUST_BACKTRACE=1
+
 cargo test -- --test-threads=1

--- a/src/api/healthcheck/test.rs
+++ b/src/api/healthcheck/test.rs
@@ -16,7 +16,7 @@ fn setup() -> Client {
     let settings = Settings::new().unwrap();
     let db = DbClient::new(&settings);
     let delivery_problems = DeliveryProblems::new(&settings, db);
-    let logger = MozlogLogger::new(&settings).expect("MozlogLogger::init error");
+    let logger = MozlogLogger::new(&settings);
     let message_data = MessageData::new(&settings);
     let providers = Providers::new(&settings);
     let server = rocket::ignite()

--- a/src/api/send/test.rs
+++ b/src/api/send/test.rs
@@ -18,7 +18,7 @@ fn setup() -> Client {
     settings.provider.forcedefault = false;
     let db = DbClient::new(&settings);
     let delivery_problems = DeliveryProblems::new(&settings, db);
-    let logger = MozlogLogger::new(&settings).expect("MozlogLogger::init error");
+    let logger = MozlogLogger::new(&settings);
     let message_data = MessageData::new(&settings);
     let providers = Providers::new(&settings);
     let server = rocket::ignite()

--- a/src/bin/queues.rs
+++ b/src/bin/queues.rs
@@ -75,7 +75,7 @@ fn main() {
         register_panic_handler();
     }
 
-    let logger = MozlogLogger::new(&SETTINGS).expect("MozlogLogger::init error");
+    let logger = MozlogLogger::new(&SETTINGS);
     let _guard = slog_scope::set_global_logger(logger.0);
     let process_queues: &Fn(usize) -> LoopResult = &|previous_count: usize| {
         let future = QUEUES

--- a/src/bin/service.rs
+++ b/src/bin/service.rs
@@ -29,6 +29,7 @@ use fxa_email_service::{
     logging::MozlogLogger,
     providers::Providers,
     settings::Settings,
+    types::logging::LogLevel,
 };
 
 fn main() {
@@ -51,14 +52,14 @@ fn main() {
 
     let db = DbClient::new(&settings);
     let delivery_problems = DeliveryProblems::new(&settings, db);
-    let logger = MozlogLogger::new(&settings).expect("MozlogLogger::init error");
+    let logger = MozlogLogger::new(&settings);
     let message_data = MessageData::new(&settings);
     let providers = Providers::new(&settings);
 
     let config = settings
         .build_rocket_config()
         .expect("Error creating rocket config");
-    rocket::custom(config, settings.log.level.as_ref() != "off")
+    rocket::custom(config, settings.log.level != LogLevel::Off)
         .manage(settings)
         .manage(delivery_problems)
         .manage(logger)

--- a/src/settings/test.rs
+++ b/src/settings/test.rs
@@ -186,15 +186,15 @@ fn env_vars_take_precedence() {
             };
 
             let log = Log {
-                level: if settings.log.level == LoggingLevel("debug".to_string()) {
-                    LoggingLevel("off".to_string())
+                level: if settings.log.level == LogLevel::Debug {
+                    LogLevel::Off
                 } else {
-                    LoggingLevel("debug".to_string())
+                    LogLevel::Debug
                 },
-                format: if settings.log.format == LoggingFormat("null".to_string()) {
-                    LoggingFormat("pretty".to_string())
+                format: if settings.log.format == LogFormat::Mozlog {
+                    LogFormat::Pretty
                 } else {
-                    LoggingFormat("null".to_string())
+                    LogFormat::Mozlog
                 },
             };
 
@@ -215,8 +215,8 @@ fn env_vars_take_precedence() {
             );
             env::set_var("FXA_EMAIL_HMACKEY", &hmac_key.to_string());
             env::set_var("FXA_EMAIL_ENV", current_env.as_ref());
-            env::set_var("FXA_EMAIL_LOG_LEVEL", &log.level.0);
-            env::set_var("FXA_EMAIL_LOG_FORMAT", &log.format.0);
+            env::set_var("FXA_EMAIL_LOG_LEVEL", log.level.as_ref());
+            env::set_var("FXA_EMAIL_LOG_FORMAT", log.format.as_ref());
             env::set_var("FXA_EMAIL_PROVIDER_DEFAULT", provider.default.as_ref());
             env::set_var(
                 "FXA_EMAIL_PROVIDER_FORCEDEFAULT",

--- a/src/types/error/mod.rs
+++ b/src/types/error/mod.rs
@@ -191,6 +191,12 @@ pub enum AppErrorKind {
 
     #[fail(display = "Invalid environment: {}", _0)]
     InvalidEnv(String),
+
+    #[fail(display = "Invalid log level: {}", _0)]
+    InvalidLogLevel(String),
+
+    #[fail(display = "Invalid log format: {}", _0)]
+    InvalidLogFormat(String),
 }
 
 impl AppErrorKind {
@@ -217,6 +223,8 @@ impl AppErrorKind {
             AppErrorKind::SoftBounce { .. } => Some(107),
             AppErrorKind::HardBounce { .. } => Some(108),
             AppErrorKind::InvalidEnv { .. } => Some(109),
+            AppErrorKind::InvalidLogLevel { .. } => Some(110),
+            AppErrorKind::InvalidLogFormat { .. } => Some(111),
         }
     }
 

--- a/src/types/logging/mod.rs
+++ b/src/types/logging/mod.rs
@@ -1,0 +1,36 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Logging types.
+
+#[cfg(test)]
+mod test;
+
+use serde::de::Error;
+
+use types::error::{AppError, AppErrorKind};
+
+enum_boilerplate!(LogLevel ("log level", InvalidLogLevel) {
+    Normal => "normal",
+    Debug => "debug",
+    Critical => "critical",
+    Off => "off",
+});
+
+impl Default for LogLevel {
+    fn default() -> Self {
+        LogLevel::Normal
+    }
+}
+
+enum_boilerplate!(LogFormat ("log format", InvalidLogFormat) {
+    Mozlog => "mozlog",
+    Pretty => "pretty",
+});
+
+impl Default for LogFormat {
+    fn default() -> Self {
+        LogFormat::Mozlog
+    }
+}

--- a/src/types/logging/test.rs
+++ b/src/types/logging/test.rs
@@ -1,0 +1,62 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+
+use std::convert::TryFrom;
+
+use super::*;
+
+#[test]
+fn level_try_from() {
+    let result: Result<LogLevel, AppError> = TryFrom::try_from("normal");
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), LogLevel::Normal);
+
+    let result: Result<LogLevel, AppError> = TryFrom::try_from("debug");
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), LogLevel::Debug);
+
+    let result: Result<LogLevel, AppError> = TryFrom::try_from("critical");
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), LogLevel::Critical);
+
+    let result: Result<LogLevel, AppError> = TryFrom::try_from("off");
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), LogLevel::Off);
+
+    let result: Result<LogLevel, AppError> = TryFrom::try_from("wibble");
+    assert!(result.is_err());
+    assert_eq!(result.unwrap_err().to_string(), "Invalid log level: wibble");
+}
+
+#[test]
+fn level_as_ref() {
+    assert_eq!(LogLevel::Normal.as_ref(), "normal");
+    assert_eq!(LogLevel::Debug.as_ref(), "debug");
+    assert_eq!(LogLevel::Critical.as_ref(), "critical");
+    assert_eq!(LogLevel::Off.as_ref(), "off");
+}
+
+#[test]
+fn format_try_from() {
+    let result: Result<LogFormat, AppError> = TryFrom::try_from("mozlog");
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), LogFormat::Mozlog);
+
+    let result: Result<LogFormat, AppError> = TryFrom::try_from("pretty");
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), LogFormat::Pretty);
+
+    let result: Result<LogFormat, AppError> = TryFrom::try_from("wibble");
+    assert!(result.is_err());
+    assert_eq!(
+        result.unwrap_err().to_string(),
+        "Invalid log format: wibble"
+    );
+}
+
+#[test]
+fn format_as_ref() {
+    assert_eq!(LogFormat::Mozlog.as_ref(), "mozlog");
+    assert_eq!(LogFormat::Pretty.as_ref(), "pretty");
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -70,5 +70,6 @@ pub mod email_address;
 pub mod env;
 pub mod error;
 pub mod headers;
+pub mod logging;
 pub mod provider;
 pub mod validate;

--- a/src/types/validate/mod.rs
+++ b/src/types/validate/mod.rs
@@ -29,8 +29,6 @@ lazy_static! {
         r"^[a-zA-Z0-9.\pL\pN!#$%&’*+/=?^_`{|}~-]{1,64}@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,253}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,253}[a-zA-Z0-9])?)+$"
     ).unwrap();
     static ref HOST_FORMAT: Regex = Regex::new(r"^[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*$").unwrap();
-    static ref LOGGING_LEVEL: Regex = Regex::new(r"^(?:normal|debug|critical|off)$").unwrap();
-    static ref LOGGING_FORMAT: Regex = Regex::new(r"^(?:mozlog|pretty|null)$").unwrap();
     static ref SENDER_NAME_FORMAT: Regex =
         Regex::new(r"^[A-Za-z0-9-]+(?: [A-Za-z0-9-]+)*$").unwrap();
     static ref SENDGRID_API_KEY_FORMAT: Regex = Regex::new("^[A-Za-z0-9._-]+$").unwrap();
@@ -68,16 +66,6 @@ pub fn email_address(value: &str) -> bool {
 /// Validate a host name or IP address.
 pub fn host(value: &str) -> bool {
     HOST_FORMAT.is_match(value)
-}
-
-/// Validate logging level.
-pub fn logging_level(value: &str) -> bool {
-    LOGGING_LEVEL.is_match(value)
-}
-
-/// Validate logging format.
-pub fn logging_format(value: &str) -> bool {
-    LOGGING_FORMAT.is_match(value)
 }
 
 /// Validate a sender name.

--- a/src/types/validate/test.rs
+++ b/src/types/validate/test.rs
@@ -135,23 +135,6 @@ fn host() {
 }
 
 #[test]
-fn logging_level() {
-    assert!(validate::logging_level("normal"));
-    assert!(validate::logging_level("debug"));
-    assert!(validate::logging_level("critical"));
-    assert!(validate::logging_level("off"));
-    assert_eq!(false, validate::logging_level("something else"));
-}
-
-#[test]
-fn logging_format() {
-    assert!(validate::logging_format("mozlog"));
-    assert!(validate::logging_format("pretty"));
-    assert!(validate::logging_format("null"));
-    assert_eq!(false, validate::logging_format("something else"));
-}
-
-#[test]
 fn invalid_host() {
     assert_eq!(validate::host("foo/bar"), false);
     assert_eq!(validate::host("foo:bar"), false);


### PR DESCRIPTION
Related to #216.

As well as creating the two enums, this change removes the `null` setting for `LogFormat`, because we already have `LogLevel::Off` and having two different ways to achieve the same thing seemed like a recipe for confusion.

@mozilla/fxa-devs r?