### PR TITLE
refactor(settings): implement Default in enum_boilerplate!

### DIFF
--- a/src/types/env/mod.rs
+++ b/src/types/env/mod.rs
@@ -11,14 +11,8 @@ use serde::de::Error;
 
 use types::error::{AppError, AppErrorKind};
 
-enum_boilerplate!(Env ("env", InvalidEnv) {
+enum_boilerplate!(Env ("env", Dev, InvalidEnv) {
     Dev => "dev",
     Prod => "production",
     Test => "test",
 });
-
-impl Default for Env {
-    fn default() -> Self {
-        Env::Dev
-    }
-}

--- a/src/types/logging/mod.rs
+++ b/src/types/logging/mod.rs
@@ -11,26 +11,14 @@ use serde::de::Error;
 
 use types::error::{AppError, AppErrorKind};
 
-enum_boilerplate!(LogLevel ("log level", InvalidLogLevel) {
+enum_boilerplate!(LogLevel ("log level", Normal, InvalidLogLevel) {
     Normal => "normal",
     Debug => "debug",
     Critical => "critical",
     Off => "off",
 });
 
-impl Default for LogLevel {
-    fn default() -> Self {
-        LogLevel::Normal
-    }
-}
-
-enum_boilerplate!(LogFormat ("log format", InvalidLogFormat) {
+enum_boilerplate!(LogFormat ("log format", Mozlog, InvalidLogFormat) {
     Mozlog => "mozlog",
     Pretty => "pretty",
 });
-
-impl Default for LogFormat {
-    fn default() -> Self {
-        LogFormat::Mozlog
-    }
-}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -7,7 +7,7 @@
 //! miscellaneous generally-used types.
 
 macro_rules! enum_boilerplate {
-    ($name:ident ($description:expr, $error:ident) {
+    ($name:ident ($description:expr, $default:ident, $error:ident) {
         $($variant:ident => $serialization:expr,)+
     }) => {
         #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
@@ -22,6 +22,12 @@ macro_rules! enum_boilerplate {
                     $($name::$variant => $serialization,
                     )+
                 }
+            }
+        }
+
+        impl std::default::Default for $name {
+            fn default() -> Self {
+                $name::$default
             }
         }
 

--- a/src/types/provider/mod.rs
+++ b/src/types/provider/mod.rs
@@ -11,16 +11,10 @@ use serde::de::Error;
 
 use types::error::{AppError, AppErrorKind};
 
-enum_boilerplate!(Provider ("env", InvalidPayload) {
+enum_boilerplate!(Provider ("env", Ses, InvalidPayload) {
     Mock => "mock",
     Sendgrid => "sendgrid",
     Ses => "ses",
     Smtp => "smtp",
     SocketLabs => "socketlabs",
 });
-
-impl Default for Provider {
-    fn default() -> Self {
-        Provider::Ses
-    }
-}


### PR DESCRIPTION
Fixes #216.

The last part of the enum refactoring, since all our enums have a default value we may as well implement `Default` in `enum_boilerplate!` too.

The other thing mentioned for #216 was to use `rusoto_core::Region` but actually it doesn't work so well for us. The serialised format is an array, `[ name, endpoint ]`, whereas we only want to specify the name in our settings. So I figure we can leave it like it is for now and decide whether we want to implement our own `AwsRegion` type later.

@mozilla/fxa-devs r?