### PR TITLE
feat(types): implement a serializable regex type

### DIFF
--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -78,4 +78,5 @@ pub mod error;
 pub mod headers;
 pub mod logging;
 pub mod provider;
+pub mod regex;
 pub mod validate;

--- a/src/types/regex/mod.rs
+++ b/src/types/regex/mod.rs
@@ -1,0 +1,46 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Regex types.
+
+use regex::Regex;
+use serde::{
+    de::{Deserialize, Deserializer, Error as SerdeError, Unexpected},
+    ser::{Serialize, Serializer},
+};
+
+#[cfg(test)]
+mod test;
+
+/// A regex wrapper
+/// that can be (de)serialized.
+#[derive(Clone, Debug)]
+pub struct SerializableRegex(pub Regex);
+
+impl<'d> Deserialize<'d> for SerializableRegex {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'d>,
+    {
+        let value: String = Deserialize::deserialize(deserializer)?;
+        Regex::new(&value)
+            .map(SerializableRegex)
+            .map_err(|_| D::Error::invalid_value(Unexpected::Str(&value), &"regular expression"))
+    }
+}
+
+impl PartialEq for SerializableRegex {
+    fn eq(&self, rhs: &Self) -> bool {
+        self.0.as_str() == rhs.0.as_str()
+    }
+}
+
+impl Serialize for SerializableRegex {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.0.as_str())
+    }
+}

--- a/src/types/regex/test.rs
+++ b/src/types/regex/test.rs
@@ -1,0 +1,15 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, you can obtain one at https://mozilla.org/MPL/2.0/.
+
+use super::*;
+
+#[test]
+fn serialize_deserialize() {
+    let regex = SerializableRegex(Regex::new("foo").unwrap());
+    let serialized = serde_json::to_string(&regex).unwrap();
+    assert_eq!(serialized, "\"foo\"");
+
+    let regex: SerializableRegex = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(regex.0.as_str(), "foo");
+}


### PR DESCRIPTION
Extraction from #258.

The configuration endpoint will have a regex property in the payload, which will also be written to Redis. Since `regex::Regex` doesn't provide implementations of `Deserialize` or `Serialize`, we must wrap it to implement them ourselves. This change does that by just serializing the string representation of the regex.

@mozilla/fxa-devs r?