### PR TITLE
feat(code): update to rust 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fxa_email_service"
 version = "1.126.0"
 publish = false
+edition = "2018"
 
 [[bin]]
 name = "fxa_email_send"

--- a/src/api/healthcheck/mod.rs
+++ b/src/api/healthcheck/mod.rs
@@ -13,8 +13,7 @@ use rocket::State;
 use rocket_contrib::Json;
 use serde_json;
 
-use settings::Settings;
-use types::error::AppResult;
+use crate::{settings::Settings, types::error::AppResult};
 
 #[cfg(test)]
 mod test;

--- a/src/api/healthcheck/test.rs
+++ b/src/api/healthcheck/test.rs
@@ -7,10 +7,12 @@ use std::env;
 use rocket::{self, http::Status, local::Client};
 use serde_json::{self, Value};
 
-use db::{auth_db::DbClient, delivery_problems::DeliveryProblems, message_data::MessageData};
-use logging::MozlogLogger;
-use providers::Providers;
-use settings::Settings;
+use crate::{
+    db::{auth_db::DbClient, delivery_problems::DeliveryProblems, message_data::MessageData},
+    logging::MozlogLogger,
+    providers::Providers,
+    settings::Settings,
+};
 
 fn setup() -> Client {
     let settings = Settings::new().unwrap();

--- a/src/api/send/mod.rs
+++ b/src/api/send/mod.rs
@@ -12,12 +12,14 @@ use rocket::{
 };
 use rocket_contrib::Json;
 
-use db::{auth_db::DbClient, delivery_problems::DeliveryProblems, message_data::MessageData};
-use logging::MozlogLogger;
-use providers::{Headers, Providers};
-use types::{
-    email_address::EmailAddress,
-    error::{AppError, AppErrorKind, AppResult},
+use crate::{
+    db::{auth_db::DbClient, delivery_problems::DeliveryProblems, message_data::MessageData},
+    logging::MozlogLogger,
+    providers::{Headers, Providers},
+    types::{
+        email_address::EmailAddress,
+        error::{AppError, AppErrorKind, AppResult},
+    },
 };
 
 #[cfg(test)]

--- a/src/api/send/test.rs
+++ b/src/api/send/test.rs
@@ -7,11 +7,13 @@ use rocket::{
     local::Client,
 };
 
-use db::{auth_db::DbClient, delivery_problems::DeliveryProblems, message_data::MessageData};
-use logging::MozlogLogger;
-use providers::Providers;
-use settings::Settings;
-use types::error::{AppError, AppErrorKind};
+use crate::{
+    db::{auth_db::DbClient, delivery_problems::DeliveryProblems, message_data::MessageData},
+    logging::MozlogLogger,
+    providers::Providers,
+    settings::Settings,
+    types::error::{AppError, AppErrorKind},
+};
 
 fn setup() -> Client {
     let mut settings = Settings::new().unwrap();

--- a/src/db/auth_db/mod.rs
+++ b/src/db/auth_db/mod.rs
@@ -25,10 +25,12 @@ use reqwest::{Client as RequestClient, Url, UrlError};
 use super::delivery_problems::{
     LegacyDeliveryProblem as DeliveryProblem, ProblemSubtype, ProblemType,
 };
-use settings::Settings;
-use types::{
-    email_address::EmailAddress,
-    error::{AppErrorKind, AppResult},
+use crate::{
+    settings::Settings,
+    types::{
+        email_address::EmailAddress,
+        error::{AppErrorKind, AppResult},
+    },
 };
 
 #[cfg(test)]

--- a/src/db/core/mod.rs
+++ b/src/db/core/mod.rs
@@ -23,8 +23,7 @@ use serde::{de::DeserializeOwned, ser::Serialize};
 use serde_json;
 use sha2::Sha256;
 
-use settings::Settings;
-use types::error::AppResult;
+use crate::{settings::Settings, types::error::AppResult};
 
 /// Database client.
 ///

--- a/src/db/delivery_problems/mod.rs
+++ b/src/db/delivery_problems/mod.rs
@@ -19,11 +19,13 @@ use super::{
     auth_db::Db as AuthDb,
     core::{Client as DbClient, DataType},
 };
-use queues::notification::{BounceSubtype, BounceType, ComplaintFeedbackType};
-use settings::{DeliveryProblemLimit, DeliveryProblemLimits, Settings};
-use types::{
-    email_address::EmailAddress,
-    error::{AppErrorKind, AppResult},
+use crate::{
+    queues::notification::{BounceSubtype, BounceType, ComplaintFeedbackType},
+    settings::{DeliveryProblemLimit, DeliveryProblemLimits, Settings},
+    types::{
+        email_address::EmailAddress,
+        error::{AppErrorKind, AppResult},
+    },
 };
 
 /// Bounce/complaint registry.

--- a/src/db/delivery_problems/test.rs
+++ b/src/db/delivery_problems/test.rs
@@ -7,13 +7,15 @@ use std::{thread::sleep, time::Duration};
 use serde_json::{self, Value as Json};
 
 use super::*;
-use db::{
-    auth_db::{Db, DbClient},
-    core::test::TestFixture,
+use crate::{
+    db::{
+        auth_db::{Db, DbClient},
+        core::test::TestFixture,
+    },
+    queues::notification::{BounceSubtype, BounceType, ComplaintFeedbackType},
+    settings::{Host, Settings},
+    types::error::{AppErrorKind, AppResult},
 };
-use queues::notification::{BounceSubtype, BounceType, ComplaintFeedbackType};
-use settings::{Host, Settings};
-use types::error::{AppErrorKind, AppResult};
 
 const SECOND: u64 = 1000;
 const MINUTE: u64 = SECOND * 60;

--- a/src/db/message_data/mod.rs
+++ b/src/db/message_data/mod.rs
@@ -5,8 +5,7 @@
 //! Storage for message metadata.
 
 use super::core::{Client as DbClient, DataType};
-use settings::Settings;
-use types::error::AppResult;
+use crate::{settings::Settings, types::error::AppResult};
 
 #[cfg(test)]
 mod test;

--- a/src/db/message_data/test.rs
+++ b/src/db/message_data/test.rs
@@ -5,7 +5,7 @@
 use std::time::SystemTime;
 
 use super::*;
-use db::core::test::TestFixture;
+use crate::db::core::test::TestFixture;
 
 #[test]
 fn set() {

--- a/src/logging/mod.rs
+++ b/src/logging/mod.rs
@@ -14,10 +14,12 @@ use slog_async;
 use slog_mozlog_json::MozLogJson;
 use slog_term;
 
-use settings::Settings;
-use types::{
-    error::AppError,
-    logging::{LogFormat, LogLevel},
+use crate::{
+    settings::Settings,
+    types::{
+        error::AppError,
+        logging::{LogFormat, LogLevel},
+    },
 };
 
 lazy_static! {

--- a/src/providers/mock.rs
+++ b/src/providers/mock.rs
@@ -3,7 +3,7 @@
 // file, you can obtain one at https://mozilla.org/MPL/2.0/.
 
 use super::{Headers, Provider};
-use types::error::AppResult;
+use crate::types::error::AppResult;
 
 pub struct MockProvider;
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -12,11 +12,13 @@ use self::{
     mock::MockProvider as Mock, sendgrid::SendgridProvider as Sendgrid, ses::SesProvider as Ses,
     smtp::SmtpProvider as Smtp, socketlabs::SocketLabsProvider as SocketLabs,
 };
-use settings::Settings;
-use types::{
-    error::{AppErrorKind, AppResult},
-    headers::*,
-    provider::Provider as ProviderType,
+use crate::{
+    settings::Settings,
+    types::{
+        error::{AppErrorKind, AppResult},
+        headers::*,
+        provider::Provider as ProviderType,
+    },
 };
 
 mod mock;

--- a/src/providers/sendgrid.rs
+++ b/src/providers/sendgrid.rs
@@ -8,8 +8,10 @@ use sendgrid::v3::{
 };
 
 use super::{Headers, Provider};
-use settings::{Sender, Sendgrid as SendgridSettings, Settings};
-use types::error::{AppErrorKind, AppResult};
+use crate::{
+    settings::{Sender, Sendgrid as SendgridSettings, Settings},
+    types::error::{AppErrorKind, AppResult},
+};
 
 pub struct SendgridProvider {
     client: Client,

--- a/src/providers/ses/mod.rs
+++ b/src/providers/ses/mod.rs
@@ -10,8 +10,7 @@ use rusoto_credential::StaticProvider;
 use rusoto_ses::{RawMessage, SendRawEmailRequest, Ses, SesClient};
 
 use super::{build_multipart_mime, Headers, Provider};
-use settings::Settings;
-use types::error::AppResult;
+use crate::{settings::Settings, types::error::AppResult};
 
 #[cfg(test)]
 mod test;

--- a/src/providers/smtp.rs
+++ b/src/providers/smtp.rs
@@ -6,8 +6,10 @@ use lettre::{ClientSecurity, EmailTransport, SmtpTransport};
 use lettre_email::{EmailBuilder, Header as LettreHeader};
 
 use super::{Headers, Provider};
-use settings::{Settings, SmtpCredentials};
-use types::error::{AppErrorKind, AppResult};
+use crate::{
+    settings::{Settings, SmtpCredentials},
+    types::error::{AppErrorKind, AppResult},
+};
 
 pub struct SmtpProvider {
     host: String,

--- a/src/providers/socketlabs.rs
+++ b/src/providers/socketlabs.rs
@@ -6,8 +6,10 @@ use socketlabs::{message::Message, request::Request, response::PostMessageErrorC
 use uuid::Uuid;
 
 use super::{Headers, Provider};
-use settings::{Sender, Settings, SocketLabs as SocketLabsSettings};
-use types::error::{AppErrorKind, AppResult};
+use crate::{
+    settings::{Sender, Settings, SocketLabs as SocketLabsSettings},
+    types::error::{AppErrorKind, AppResult},
+};
 
 pub struct SocketLabsProvider {
     settings: SocketLabsSettings,

--- a/src/queues/mock.rs
+++ b/src/queues/mock.rs
@@ -11,8 +11,7 @@ use super::{
     },
     DeleteFuture, Factory, Incoming, Message, Outgoing, ReceiveFuture, SendFuture,
 };
-use settings::Settings;
-use types::error::AppErrorKind;
+use crate::{settings::Settings, types::error::AppErrorKind};
 
 #[derive(Debug)]
 pub struct Queue {

--- a/src/queues/mod.rs
+++ b/src/queues/mod.rs
@@ -11,10 +11,12 @@ use slog_scope;
 
 use self::notification::{Notification, NotificationType};
 pub use self::sqs::Queue as Sqs;
-use db::{auth_db::DbClient, delivery_problems::DeliveryProblems, message_data::MessageData};
-use logging::MozlogLogger;
-use settings::Settings;
-use types::error::{AppError, AppErrorKind, AppResult};
+use crate::{
+    db::{auth_db::DbClient, delivery_problems::DeliveryProblems, message_data::MessageData},
+    logging::MozlogLogger,
+    settings::Settings,
+    types::error::{AppError, AppErrorKind, AppResult},
+};
 
 mod mock;
 pub mod notification;

--- a/src/queues/notification.rs
+++ b/src/queues/notification.rs
@@ -9,7 +9,7 @@ use chrono::{DateTime, Utc};
 pub use super::sqs::notification::{
     BounceSubtype, BounceType, ComplaintFeedbackType, Header, HeaderValue, NotificationType,
 };
-use types::email_address::EmailAddress;
+use crate::types::email_address::EmailAddress;
 
 /// The root notification type.
 ///

--- a/src/queues/sqs/mod.rs
+++ b/src/queues/sqs/mod.rs
@@ -26,9 +26,11 @@ use super::{
     notification::Notification, DeleteFuture, Factory, Incoming, Message, Outgoing, ReceiveFuture,
     SendFuture,
 };
-use logging::MozlogLogger;
-use settings::Settings;
-use types::error::{AppError, AppErrorKind, AppResult};
+use crate::{
+    logging::MozlogLogger,
+    settings::Settings,
+    types::error::{AppError, AppErrorKind, AppResult},
+};
 
 pub mod notification;
 

--- a/src/queues/sqs/notification/mod.rs
+++ b/src/queues/sqs/notification/mod.rs
@@ -16,8 +16,10 @@ use super::super::notification::{
     Bounce as GenericBounce, Complaint as GenericComplaint, Delivery as GenericDelivery,
     Mail as GenericMail, Notification as GenericNotification,
 };
-use db::delivery_problems::{ProblemSubtype, ProblemType};
-use types::email_address::EmailAddress;
+use crate::{
+    db::delivery_problems::{ProblemSubtype, ProblemType},
+    types::email_address::EmailAddress,
+};
 
 #[cfg(test)]
 mod test;

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -21,14 +21,16 @@ use rocket::config::{
 };
 use serde::de::{Deserialize, Deserializer, Error, Unexpected};
 
-use logging::MozlogLogger;
-use types::{
-    duration::Duration,
-    email_address::EmailAddress,
-    env::Env,
-    logging::{LogFormat, LogLevel},
-    provider::Provider as ProviderType,
-    validate,
+use crate::{
+    logging::MozlogLogger,
+    types::{
+        duration::Duration,
+        email_address::EmailAddress,
+        env::Env,
+        logging::{LogFormat, LogLevel},
+        provider::Provider as ProviderType,
+        validate,
+    },
 };
 
 macro_rules! deserialize_and_validate {

--- a/src/types/duration/mod.rs
+++ b/src/types/duration/mod.rs
@@ -9,7 +9,7 @@ use std::convert::{From, TryFrom};
 use regex::Regex;
 use serde::de::{Deserialize, Deserializer, Error as SerdeError, Unexpected};
 
-use types::error::{AppError, AppErrorKind, AppResult};
+use crate::types::error::{AppError, AppErrorKind, AppResult};
 
 #[cfg(test)]
 mod test;

--- a/src/types/env/mod.rs
+++ b/src/types/env/mod.rs
@@ -9,7 +9,7 @@ mod test;
 
 use serde::de::Error;
 
-use types::error::{AppError, AppErrorKind};
+use crate::types::error::{AppError, AppErrorKind};
 
 enum_boilerplate!(Env ("env", Dev, InvalidEnv) {
     Dev => "dev",

--- a/src/types/error/mod.rs
+++ b/src/types/error/mod.rs
@@ -31,8 +31,7 @@ use serde_json::{map::Map, ser::to_string, Error as JsonError, Value};
 use socketlabs::error::Error as SocketLabsError;
 
 use super::email_address::EmailAddress;
-use db::delivery_problems::DeliveryProblem;
-use logging::MozlogLogger;
+use crate::{db::delivery_problems::DeliveryProblem, logging::MozlogLogger};
 
 #[cfg(test)]
 mod test;

--- a/src/types/error/test.rs
+++ b/src/types/error/test.rs
@@ -5,7 +5,7 @@
 use chrono::Utc;
 
 use super::*;
-use db::delivery_problems::{ProblemSubtype, ProblemType};
+use crate::db::delivery_problems::{ProblemSubtype, ProblemType};
 
 #[test]
 fn internal() {

--- a/src/types/logging/mod.rs
+++ b/src/types/logging/mod.rs
@@ -9,7 +9,7 @@ mod test;
 
 use serde::de::Error;
 
-use types::error::{AppError, AppErrorKind};
+use crate::types::error::{AppError, AppErrorKind};
 
 enum_boilerplate!(LogLevel ("log level", Normal, InvalidLogLevel) {
     Normal => "normal",

--- a/src/types/provider/mod.rs
+++ b/src/types/provider/mod.rs
@@ -9,7 +9,7 @@ mod test;
 
 use serde::de::Error;
 
-use types::error::{AppError, AppErrorKind};
+use crate::types::error::{AppError, AppErrorKind};
 
 enum_boilerplate!(Provider ("env", Ses, InvalidPayload) {
     Mock => "mock",

--- a/src/types/validate/test.rs
+++ b/src/types/validate/test.rs
@@ -4,7 +4,7 @@
 
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 
-use types::validate;
+use crate::types::validate;
 
 fn random_alphanum_string(len: usize) -> String {
     thread_rng().sample_iter(&Alphanumeric).take(len).collect()


### PR DESCRIPTION
This is just the result of running `cargo fix --edition` then `cargo fmt`. There's other changes we could make to be more idiomatically 2018 (like removing `extern crate` and explicitly `use`-ing macros), but this is a fair start.

@mozilla/fxa-devs r?