### PR TITLE
fix(api): use correct apostrophe character in email address regex

### DIFF
--- a/src/types/validate/mod.rs
+++ b/src/types/validate/mod.rs
@@ -26,7 +26,7 @@ lazy_static! {
         r"^https?://[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*(?::[0-9]+)?/(?:[A-Za-z0-9-]+/)*$"
     ).unwrap();
     static ref EMAIL_ADDRESS_FORMAT: Regex = Regex::new(
-        r"^[a-zA-Z0-9.\pL\pN!#$%&’*+/=?^_`{|}~-]{1,64}@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,253}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,253}[a-zA-Z0-9])?)+$"
+        r"^[a-zA-Z0-9.\pL\pN!#$%&'*+/=?^_`{|}~-]{1,64}@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,253}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,253}[a-zA-Z0-9])?)+$"
     ).unwrap();
     static ref HOST_FORMAT: Regex = Regex::new(r"^[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*$").unwrap();
     static ref SENDER_NAME_FORMAT: Regex =

--- a/src/types/validate/test.rs
+++ b/src/types/validate/test.rs
@@ -108,6 +108,7 @@ fn email_address() {
         "a@{}.b",
         random_alphanum_string(249)
     )));
+    assert!(validate::email_address("a'b@example.com"));
 }
 
 #[test]
@@ -125,6 +126,7 @@ fn invalid_email_address() {
         "a@{}.b",
         random_alphanum_string(250)
     )));
+    assert!(!validate::email_address("a’b@example.com"));
 }
 
 #[test]


### PR DESCRIPTION
Fixes #273.

Same underlying issue as mozilla/fxa-content-server#6702. Typing is hard.

@mozilla/fxa-devs r?